### PR TITLE
LLVM-IR generation for TFunMap and TFunSel AST nodes

### DIFF
--- a/src/astlowering/ClosureConversion.ml
+++ b/src/astlowering/ClosureConversion.ml
@@ -112,8 +112,7 @@ module ScillaCG_CloCnv = struct
                 let erep' =
                   {
                     ea_loc = brep.ea_loc;
-                    ea_tp =
-                      Option.map brep.ea_tp ~f:(fun t -> FunType ([], t));
+                    ea_tp = Option.map brep.ea_tp ~f:(fun t -> FunType ([], t));
                     ea_auxi = brep.ea_auxi;
                   }
                 in

--- a/src/astlowering/ClosureConversion.ml
+++ b/src/astlowering/ClosureConversion.ml
@@ -113,7 +113,7 @@ module ScillaCG_CloCnv = struct
                   {
                     ea_loc = brep.ea_loc;
                     ea_tp =
-                      Option.map brep.ea_tp ~f:(fun t -> FunType ([ Unit ], t));
+                      Option.map brep.ea_tp ~f:(fun t -> FunType ([], t));
                     ea_auxi = brep.ea_auxi;
                   }
                 in

--- a/src/astlowering/Monomorphize.ml
+++ b/src/astlowering/Monomorphize.ml
@@ -1339,7 +1339,7 @@ module ScillaCG_Mmph = struct
           (* For each type t in tys, specialize sube for t and
            * and recursively apply with contexts in which t appears. *)
           mapM (TypMap.Map.to_alist tys') ~f:(fun (t, ctxs) ->
-              DebugMessage.pout
+              DebugMessage.plog
                 (sprintf "Specializing [%s] %s with %s\n"
                    (ErrorUtils.get_loc_str (Identifier.get_rep tv).ea_loc)
                    (Identifier.get_id tv) (pp_typ t));

--- a/src/astlowering/UncurriedSyntax.ml
+++ b/src/astlowering/UncurriedSyntax.ml
@@ -886,9 +886,6 @@ module Uncurried_Syntax = struct
       in
       rename_bound_vars mk_new_name (const @@ Int.succ) t 1
 
-    (* The same as above, but for a variable with locations *)
-    let subst_type_in_type tv = subst_type_in_type tv
-
     let rec subst_type_in_literal tvar tp l =
       match l with
       | Map ((kt, vt), ls) ->

--- a/src/llvmgen/GenLlvm.ml
+++ b/src/llvmgen/GenLlvm.ml
@@ -589,9 +589,7 @@ let genllvm_expr genv builder (e, erep) =
             let%bind tidx = EnumTAppArgs.lookup_typ_idx genv.timap targ in
             let addr =
               Llvm.build_gep curtf
-                [|
-                  Llvm.const_int (Llvm.i32_type llctx) tidx;
-                |]
+                [| Llvm.const_int (Llvm.i32_type llctx) tidx |]
                 (tempname tfs) builder
             in
             let%bind retty = specialize_polyfun curtf_ty targ in

--- a/src/llvmgen/GenLlvm.ml
+++ b/src/llvmgen/GenLlvm.ml
@@ -78,6 +78,17 @@
  *       return value will be the second argument.
  *     - The formal parameters follow in their original order.
  *
+ *  Dynamic dispatch tables for TFunMap (monomorphized versions of expressions):
+ *    A TFunMap expressions is represented as an array of closures. Each of these
+ *    closures is of type `() -> X` where `X` is the type of the monomorphized
+ *    version of the sub-expression which was in the `TFun` Scilla expression
+ *    before monomorphization. EnumTAppArgs.lookup_typ_idx provides a unique
+ *    index for every type that may be used to index into this array.
+ *    For types (i.e., it's index) that aren't specialized here, the closure
+ *    pointers will be nullptr.
+ *    Unlike normal closures (described above), closures here are represented as
+ *    { void*, void* } for the function pointer (first component) to remain general.
+ *
  *  Interaction with SRTL / JITD
  *  A.
  *    When a builtin / function in SRTL must take / return values of different types
@@ -109,6 +120,7 @@ module Identifier = Literal.LType.TIdentifier
 open MonadUtil
 open Syntax
 open UncurriedSyntax.Uncurried_Syntax
+module TU = TypeUtilities
 open ClosuredSyntax
 open CodegenUtils
 open Printf
@@ -459,8 +471,8 @@ let genllvm_expr genv builder (e, erep) =
           if not (List.is_empty (snd fc.envvars)) then
             fail1
               (sprintf
-                 "GenLlvm: genllvm_expr: Expected closure for %s with empty \
-                  environment."
+                 "GenLlvm: genllvm_expr: Expected closure for %s with \
+                  non-empty environment."
                  (Identifier.get_id fname))
               erep.ea_loc
           else
@@ -471,9 +483,82 @@ let genllvm_expr genv builder (e, erep) =
             pure cloval
       | _ ->
           fail1
-            (sprintf "GenLlvm: genllvm:expr: Incorrect resolution of %s."
+            (sprintf "GenLlvm: genllvm_expr: Incorrect resolution of %s."
                (Identifier.get_id fname))
             erep.ea_loc )
+  | TFunMap tbodies -> (
+      let%bind t = rep_typ erep in
+      let%bind t' = genllvm_typ_fst llmod t in
+      match tbodies with
+      (* If there are no specializations, return a null value. *)
+      | [] -> pure (Llvm.const_null t')
+      | (curt, cl) :: rest ->
+          let build_closure_all envp tbodies =
+            mapM tbodies ~f:(fun (t, tbody) ->
+                let fname = !(tbody.thisfun).fname in
+                match%bind resolve_id genv fname with
+                | FunDecl gv ->
+                    let%bind clo_ty = id_typ_ll llmod fname in
+                    let%bind closure =
+                      build_closure builder clo_ty gv fname envp
+                    in
+                    pure (t, closure)
+                | _ ->
+                    fail1
+                      (sprintf
+                         "GenLlvm: genllvm_expr: Expected FunDecl resolution")
+                      erep.ea_loc)
+          in
+          let%bind tbodies' =
+            match%bind resolve_id genv (fst cl.envvars) with
+            | CloP (cp, envp) ->
+                let%bind rest' = build_closure_all envp rest in
+                pure @@ ((curt, cp) :: rest')
+            | FunDecl _ ->
+                (* Looks like no AllocCloEnv, assert empty environment. *)
+                if not (List.is_empty (snd cl.envvars)) then
+                  fail1
+                    (sprintf
+                       "GenLlvm: genllvm_expr: Expected closure for for \
+                        non-empty environment.")
+                    erep.ea_loc
+                else
+                  let envp = void_ptr_nullptr llctx in
+                  build_closure_all envp tbodies
+            | _ ->
+                fail1
+                  (sprintf "GenLlvm: genllvm_expr: Incorrect resolution of %s."
+                     (Identifier.get_id (fst cl.envvars)))
+                  erep.ea_loc
+          in
+          (* Allocate a zero initialized dyndisp table. *)
+          let%bind clo_ty = ptr_element_type t' in
+          let ddt_size = EnumTAppArgs.size genv.timap in
+          let nullinit = Array.create ~len:ddt_size (Llvm.const_null clo_ty) in
+          let ddt =
+            define_global (tempname "dyndisp")
+              (Llvm.const_array clo_ty nullinit)
+              llmod ~const:false ~unnamed:false
+          in
+          let%bind () =
+            forallM tbodies' ~f:(fun (t, tbody) ->
+                let%bind tidx = EnumTAppArgs.lookup_typ_idx genv.timap t in
+                let addr =
+                  Llvm.const_gep ddt
+                    [|
+                      Llvm.const_int (Llvm.i32_type llctx) 0;
+                      Llvm.const_int (Llvm.i32_type llctx) tidx;
+                    |]
+                in
+                let addr' =
+                  Llvm.const_pointercast addr
+                    (Llvm.pointer_type @@ Llvm.type_of tbody)
+                in
+                let _ = Llvm.build_store tbody addr' builder in
+                pure ())
+          in
+          let ddt' = Llvm.const_pointercast ddt t' in
+          pure ddt' )
   | App (f, args) ->
       (* Resolve f (to a closure value) *)
       let%bind fclo_ll = resolve_id_value genv (Some builder) f in
@@ -489,6 +574,51 @@ let genllvm_expr genv builder (e, erep) =
           builder
       in
       build_call_helper llmod genv builder f fptr args (Some envptr)
+  | TFunSel (tf, targs) ->
+      let tfs = Identifier.get_id tf in
+      let specialize_polyfun pf t =
+        match pf with
+        | PolyFun (tv, t') -> pure @@ TU.subst_type_in_type tv t t'
+        | _ ->
+            fail0 "GenLlvm: genllvm_expr: expected universally quantified type."
+      in
+      let%bind tf' = resolve_id_value genv (Some builder) tf in
+      let%bind tf_typ = id_typ tf in
+      let%bind v, _ =
+        foldM ~init:(tf', tf_typ) targs ~f:(fun (curtf, curtf_ty) targ ->
+            let%bind tidx = EnumTAppArgs.lookup_typ_idx genv.timap targ in
+            let addr =
+              Llvm.build_gep curtf
+                [|
+                  Llvm.const_int (Llvm.i32_type llctx) tidx;
+                |]
+                (tempname tfs) builder
+            in
+            let%bind retty = specialize_polyfun curtf_ty targ in
+            let fty = FunType ([], retty) in
+            let%bind clo_ty = genllvm_typ_fst llmod fty in
+            let addr' =
+              Llvm.build_pointercast addr (Llvm.pointer_type clo_ty)
+                (tempname tfs) builder
+            in
+            let curclo = Llvm.build_load addr' (tempname tfs) builder in
+            (* and extract the fundef and environment pointers. *)
+            let%bind fptr =
+              build_extractvalue curclo 0
+                (tempname (Identifier.get_id tf ^ "_fptr"))
+                builder
+            in
+            let%bind envptr =
+              build_extractvalue curclo 1
+                (tempname (Identifier.get_id tf ^ "_envptr"))
+                builder
+            in
+            let%bind curtf' =
+              build_call_helper llmod genv builder tf fptr [] (Some envptr)
+            in
+            pure (curtf', retty))
+      in
+      pure v
   | Builtin ((b, brep), args) ->
       let bname = Identifier.mk_id (pp_builtin b) brep in
       let%bind bdecl = GenSrtlDecls.decl_builtins llmod b args in
@@ -1516,9 +1646,7 @@ let genllvm_module (cmod : cmodule) =
   let%bind tydescr_map =
     TypeDescr.generate_type_descr_cmod llmod topclos cmod
   in
-  let tidx_map =
-    EnumTAppArgs.enumerate_tapp_args_cmod topclos cmod
-  in
+  let tidx_map = EnumTAppArgs.enumerate_tapp_args_cmod topclos cmod in
   (* Generate LLVM functions for all closures. *)
   let%bind genv_fdecls = genllvm_closures llmod tydescr_map tidx_map topclos in
   (* Create a function to initialize library values. *)
@@ -1557,9 +1685,7 @@ let genllvm_stmt_list_wrapper stmts =
   let%bind tydescr_map =
     TypeDescr.generate_type_descr_stmts_wrapper llmod topclos stmts
   in
-  let tidx_map =
-    EnumTAppArgs.enumerate_tapp_args_stmts_wrapper topclos stmts
-  in
+  let tidx_map = EnumTAppArgs.enumerate_tapp_args_stmts_wrapper topclos stmts in
   let%bind genv_fdecls = genllvm_closures llmod tydescr_map tidx_map topclos in
   (* Create a function to initialize library values. *)
   let%bind genv_libs = create_init_libs genv_fdecls llmod [] in

--- a/src/llvmgen/TypeLLConv.mli
+++ b/src/llvmgen/TypeLLConv.mli
@@ -108,3 +108,15 @@ module TypeDescr : sig
     typ_descr ->
     (Llvm.llvalue * Llvm.llvalue, scilla_error list) result
 end
+
+(* Enumerate all (closed) types used as arguments in a type application. *)
+module EnumTAppArgs : sig
+  type typ_idx_map
+
+  val enumerate_tapp_args_stmts_wrapper :
+    clorec list -> stmt_annot list -> typ_idx_map
+
+  val enumerate_tapp_args_cmod : clorec list -> cmodule -> typ_idx_map
+
+  val lookup_typ_idx : typ_idx_map -> typ -> (int, scilla_error list) result
+end

--- a/src/llvmgen/TypeLLConv.mli
+++ b/src/llvmgen/TypeLLConv.mli
@@ -119,4 +119,6 @@ module EnumTAppArgs : sig
   val enumerate_tapp_args_cmod : clorec list -> cmodule -> typ_idx_map
 
   val lookup_typ_idx : typ_idx_map -> typ -> (int, scilla_error list) result
+
+  val size : typ_idx_map -> int
 end

--- a/tests/codegen/expr/TestCodegenExpr.ml
+++ b/tests/codegen/expr/TestCodegenExpr.ml
@@ -25,6 +25,7 @@ let explist =
     "multi-type-inst.scilexp";
     "dce1.scilexp";
     "typ-inst.scilexp";
+    "typ1-inst.scilexp";
     "typ2-inst.scilexp";
     "typ3-inst.scilexp";
     "tfun-val.scilexp";

--- a/tests/codegen/expr/gold/exponential-growth.scilexp.gold
+++ b/tests/codegen/expr/gold/exponential-growth.scilexp.gold
@@ -1,5 +1,163 @@
-Specializing [codegen/expr/exponential-growth.scilexp:4:8] 'B with Int32
-Specializing [codegen/expr/exponential-growth.scilexp:5:8] 'C with Int64
-Specializing [codegen/expr/exponential-growth.scilexp:11:8] 'A with [Int32] -> Int64
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_12" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"TName_List_[Int32]_->_Int64" = type { i8, %"CName_Cons_[Int32]_->_Int64"*, %"CName_Nil_[Int32]_->_Int64"* }
+%"CName_Cons_[Int32]_->_Int64" = type <{ i8, { %Int64 (i8*, %Int32)*, i8* }, %"TName_List_[Int32]_->_Int64"* }>
+%"CName_Nil_[Int32]_->_Int64" = type <{ i8 }>
+%"$$fundef_10_env_37" = type {}
+%Int64 = type { i64 }
+%Int32 = type { i32 }
+%"$$fundef_8_env_38" = type {}
+%"$$fundef_6_env_39" = type {}
+%"$$fundef_4_env_40" = type {}
+%"$$fundef_2_env_41" = type {}
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_13" = global %"$TyDescrTy_PrimTyp_12" zeroinitializer
+@"$TyDescr_Int32_14" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Int32_Prim_13" to i8*) }
+@"$TyDescr_Uint32_Prim_15" = global %"$TyDescrTy_PrimTyp_12" { i32 1, i32 0 }
+@"$TyDescr_Uint32_16" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Uint32_Prim_15" to i8*) }
+@"$TyDescr_Int64_Prim_17" = global %"$TyDescrTy_PrimTyp_12" { i32 0, i32 1 }
+@"$TyDescr_Int64_18" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Int64_Prim_17" to i8*) }
+@"$TyDescr_Uint64_Prim_19" = global %"$TyDescrTy_PrimTyp_12" { i32 1, i32 1 }
+@"$TyDescr_Uint64_20" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Uint64_Prim_19" to i8*) }
+@"$TyDescr_Int128_Prim_21" = global %"$TyDescrTy_PrimTyp_12" { i32 0, i32 2 }
+@"$TyDescr_Int128_22" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Int128_Prim_21" to i8*) }
+@"$TyDescr_Uint128_Prim_23" = global %"$TyDescrTy_PrimTyp_12" { i32 1, i32 2 }
+@"$TyDescr_Uint128_24" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Uint128_Prim_23" to i8*) }
+@"$TyDescr_Int256_Prim_25" = global %"$TyDescrTy_PrimTyp_12" { i32 0, i32 3 }
+@"$TyDescr_Int256_26" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Int256_Prim_25" to i8*) }
+@"$TyDescr_Uint256_Prim_27" = global %"$TyDescrTy_PrimTyp_12" { i32 1, i32 3 }
+@"$TyDescr_Uint256_28" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Uint256_Prim_27" to i8*) }
+@"$TyDescr_String_Prim_29" = global %"$TyDescrTy_PrimTyp_12" { i32 2, i32 0 }
+@"$TyDescr_String_30" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_String_Prim_29" to i8*) }
+@"$TyDescr_Bystr_Prim_31" = global %"$TyDescrTy_PrimTyp_12" { i32 7, i32 0 }
+@"$TyDescr_Bystr_32" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_12"* @"$TyDescr_Bystr_Prim_31" to i8*) }
+@"$dyndisp_45" = global [3 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_76" = global [3 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_80" = global [3 x { i8*, i8* }] zeroinitializer
+
+define internal %"TName_List_[Int32]_->_Int64"* @"$fundef_10"(%"$$fundef_10_env_37"* %0, { %Int64 (i8*, %Int32)*, i8* } %1) {
+entry:
+  %"$retval_11" = alloca %"TName_List_[Int32]_->_Int64"*
+  %an = alloca %"TName_List_[Int32]_->_Int64"*
+  %"$adtval_62_load" = load i8*, i8** @_execptr
+  %"$adtval_62_salloc" = call i8* @_salloc(i8* %"$adtval_62_load", i64 1)
+  %"$adtval_62" = bitcast i8* %"$adtval_62_salloc" to %"CName_Nil_[Int32]_->_Int64"*
+  %"$adtgep_63" = getelementptr inbounds %"CName_Nil_[Int32]_->_Int64", %"CName_Nil_[Int32]_->_Int64"* %"$adtval_62", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_63"
+  %"$adtptr_64" = bitcast %"CName_Nil_[Int32]_->_Int64"* %"$adtval_62" to %"TName_List_[Int32]_->_Int64"*
+  store %"TName_List_[Int32]_->_Int64"* %"$adtptr_64", %"TName_List_[Int32]_->_Int64"** %an
+  %"$an_65" = load %"TName_List_[Int32]_->_Int64"*, %"TName_List_[Int32]_->_Int64"** %an
+  %"$adtval_66_load" = load i8*, i8** @_execptr
+  %"$adtval_66_salloc" = call i8* @_salloc(i8* %"$adtval_66_load", i64 25)
+  %"$adtval_66" = bitcast i8* %"$adtval_66_salloc" to %"CName_Cons_[Int32]_->_Int64"*
+  %"$adtgep_67" = getelementptr inbounds %"CName_Cons_[Int32]_->_Int64", %"CName_Cons_[Int32]_->_Int64"* %"$adtval_66", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_67"
+  %"$adtgep_68" = getelementptr inbounds %"CName_Cons_[Int32]_->_Int64", %"CName_Cons_[Int32]_->_Int64"* %"$adtval_66", i32 0, i32 1
+  store { %Int64 (i8*, %Int32)*, i8* } %1, { %Int64 (i8*, %Int32)*, i8* }* %"$adtgep_68"
+  %"$adtgep_69" = getelementptr inbounds %"CName_Cons_[Int32]_->_Int64", %"CName_Cons_[Int32]_->_Int64"* %"$adtval_66", i32 0, i32 2
+  store %"TName_List_[Int32]_->_Int64"* %"$an_65", %"TName_List_[Int32]_->_Int64"** %"$adtgep_69"
+  %"$adtptr_70" = bitcast %"CName_Cons_[Int32]_->_Int64"* %"$adtval_66" to %"TName_List_[Int32]_->_Int64"*
+  store %"TName_List_[Int32]_->_Int64"* %"$adtptr_70", %"TName_List_[Int32]_->_Int64"** %"$retval_11"
+  %"$$retval_11_71" = load %"TName_List_[Int32]_->_Int64"*, %"TName_List_[Int32]_->_Int64"** %"$retval_11"
+  ret %"TName_List_[Int32]_->_Int64"* %"$$retval_11_71"
+}
+
+define internal { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } @"$fundef_8"(%"$$fundef_8_env_38"* %0) {
+entry:
+  %"$retval_9" = alloca { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }
+  store { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })* bitcast (%"TName_List_[Int32]_->_Int64"* (%"$$fundef_10_env_37"*, { %Int64 (i8*, %Int32)*, i8* })* @"$fundef_10" to %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*), i8* null }, { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %"$retval_9"
+  %"$$retval_9_61" = load { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }, { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %"$retval_9"
+  ret { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$$retval_9_61"
+}
+
+define internal { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } @"$fundef_6"(%"$$fundef_6_env_39"* %0, { i8*, i8* }* %1) {
+entry:
+  %"$retval_7" = alloca { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }
+  %"$f_51" = getelementptr { i8*, i8* }, { i8*, i8* }* %1, i32 0
+  %"$f_52" = bitcast { i8*, i8* }* %"$f_51" to { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*, i8* }*
+  %"$f_53" = load { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*, i8* }, { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*, i8* }* %"$f_52"
+  %"$f_fptr_54" = extractvalue { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*, i8* } %"$f_53", 0
+  %"$f_envptr_55" = extractvalue { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*, i8* } %"$f_53", 1
+  %"$f_call_56" = call { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$f_fptr_54"(i8* %"$f_envptr_55")
+  store { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$f_call_56", { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %"$retval_7"
+  %"$$retval_7_57" = load { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }, { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %"$retval_7"
+  ret { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$$retval_7_57"
+}
+
+define internal { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } @"$fundef_4"(%"$$fundef_4_env_40"* %0) {
+entry:
+  %"$retval_5" = alloca { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  store { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)* bitcast ({ %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (%"$$fundef_6_env_39"*, { i8*, i8* }*)* @"$fundef_6" to { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*), i8* null }, { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_5"
+  %"$$retval_5_50" = load { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_5"
+  ret { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$retval_5_50"
+}
+
+define internal { i8*, i8* }* @"$fundef_2"(%"$$fundef_2_env_41"* %0) {
+entry:
+  %"$retval_3" = alloca { i8*, i8* }*
+  store { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)* bitcast ({ { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (%"$$fundef_4_env_40"*)* @"$fundef_4" to { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*), i8* null }, { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([3 x { i8*, i8* }], [3 x { i8*, i8* }]* @"$dyndisp_45", i32 0, i32 2) to { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([3 x { i8*, i8* }], [3 x { i8*, i8* }]* @"$dyndisp_45", i32 0, i32 0), { i8*, i8* }** %"$retval_3"
+  %"$$retval_3_46" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_3"
+  ret { i8*, i8* }* %"$$retval_3_46"
+}
+
+declare i8* @_salloc(i8*, i64)
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } @"$scilla_expr_72"(i8* %0) {
+entry:
+  %"$expr_1" = alloca { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }
+  %t = alloca { i8*, i8* }*
+  store { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_2_env_41"*)* @"$fundef_2" to { i8*, i8* }* (i8*)*), i8* null }, { { i8*, i8* }* (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([3 x { i8*, i8* }], [3 x { i8*, i8* }]* @"$dyndisp_76", i32 0, i32 1) to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([3 x { i8*, i8* }], [3 x { i8*, i8* }]* @"$dyndisp_76", i32 0, i32 0), { i8*, i8* }** %t
+  %t1 = alloca { i8*, i8* }*
+  store { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*, i8* } { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)* bitcast ({ %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (%"$$fundef_8_env_38"*)* @"$fundef_8" to { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*), i8* null }, { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*, i8* }* bitcast ([3 x { i8*, i8* }]* @"$dyndisp_80" to { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([3 x { i8*, i8* }], [3 x { i8*, i8* }]* @"$dyndisp_80", i32 0, i32 0), { i8*, i8* }** %t1
+  %f11 = alloca { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  %"$t_81" = load { i8*, i8* }*, { i8*, i8* }** %t
+  %"$t_82" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$t_81", i32 1
+  %"$t_83" = bitcast { i8*, i8* }* %"$t_82" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$t_84" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$t_83"
+  %"$t_fptr_85" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$t_84", 0
+  %"$t_envptr_86" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$t_84", 1
+  %"$t_call_87" = call { i8*, i8* }* %"$t_fptr_85"(i8* %"$t_envptr_86")
+  %"$t_88" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$t_call_87", i32 2
+  %"$t_89" = bitcast { i8*, i8* }* %"$t_88" to { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }*
+  %"$t_90" = load { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }, { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }* %"$t_89"
+  %"$t_fptr_91" = extractvalue { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } %"$t_90", 0
+  %"$t_envptr_92" = extractvalue { { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } %"$t_90", 1
+  %"$t_call_93" = call { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_fptr_91"(i8* %"$t_envptr_92")
+  store { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_call_93", { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %f11
+  %f12 = alloca { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }
+  %"$f11_0" = alloca { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }
+  %"$f11_94" = load { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %f11
+  %"$f11_fptr_95" = extractvalue { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$f11_94", 0
+  %"$f11_envptr_96" = extractvalue { { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$f11_94", 1
+  %"$t1_97" = load { i8*, i8* }*, { i8*, i8* }** %t1
+  %"$f11_call_98" = call { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$f11_fptr_95"(i8* %"$f11_envptr_96", { i8*, i8* }* %"$t1_97")
+  store { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$f11_call_98", { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %"$f11_0"
+  %"$$f11_0_99" = load { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }, { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %"$f11_0"
+  store { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$$f11_0_99", { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %f12
+  %"$f12_100" = load { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }, { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %f12
+  store { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$f12_100", { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %"$expr_1"
+  %"$$expr_1_101" = load { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }, { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* }* %"$expr_1"
+  ret { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } %"$$expr_1_101"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$cloval_102" = call { %"TName_List_[Int32]_->_Int64"* (i8*, { %Int64 (i8*, %Int32)*, i8* })*, i8* } @"$scilla_expr_72"(i8* null)
+  ret void
+}

--- a/tests/codegen/expr/gold/fun-type-inst.scilexp.gold
+++ b/tests/codegen/expr/gold/fun-type-inst.scilexp.gold
@@ -1,10 +1,510 @@
-Specializing [codegen/expr/fun-type-inst.scilexp:2:8] 'A with Int32
-Specializing [codegen/expr/fun-type-inst.scilexp:2:8] 'A with Int64
-Specializing [codegen/expr/fun-type-inst.scilexp:8:8] 'A with Int32
-Specializing [codegen/expr/fun-type-inst.scilexp:8:8] 'A with Int64
-Specializing [codegen/expr/fun-type-inst.scilexp:15:8] 'A with Int32
-Specializing [codegen/expr/fun-type-inst.scilexp:15:8] 'A with Int64
-Specializing [codegen/expr/fun-type-inst.scilexp:23:8] 'B with Int32
-Specializing [codegen/expr/fun-type-inst.scilexp:23:8] 'B with Int64
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_39" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$TyDescrTy_ADTTyp_61" = type { %TyDescrString, i32, i32, i32, %"$TyDescrTy_ADTTyp_Specl_60"** }
+%TyDescrString = type { i8*, i32 }
+%"$TyDescrTy_ADTTyp_Specl_60" = type { %_TyDescrTy_Typ**, %"$TyDescrTy_ADTTyp_Constr_62"**, %"$TyDescrTy_ADTTyp_61"* }
+%"$TyDescrTy_ADTTyp_Constr_62" = type { %TyDescrString, i32, %_TyDescrTy_Typ** }
+%TName_List_Int64 = type { i8, %CName_Cons_Int64*, %CName_Nil_Int64* }
+%CName_Cons_Int64 = type <{ i8, %Int64, %TName_List_Int64* }>
+%CName_Nil_Int64 = type <{ i8 }>
+%Int64 = type { i64 }
+%"$$fundef_37_env_100" = type {}
+%"$$fundef_35_env_101" = type {}
+%TName_List_Int32 = type { i8, %CName_Cons_Int32*, %CName_Nil_Int32* }
+%CName_Cons_Int32 = type <{ i8, %Int32, %TName_List_Int32* }>
+%CName_Nil_Int32 = type <{ i8 }>
+%Int32 = type { i32 }
+%"$$fundef_33_env_102" = type {}
+%"$$fundef_31_env_103" = type {}
+%"$$fundef_29_env_104" = type {}
+%"$$fundef_27_env_105" = type {}
+%"$$fundef_25_env_106" = type {}
+%"$$fundef_23_env_107" = type {}
+%"$$fundef_21_env_108" = type {}
+%"$$fundef_19_env_109" = type {}
+%"$$fundef_17_env_110" = type {}
+%"$$fundef_15_env_111" = type {}
+%"$$fundef_13_env_112" = type {}
+%"$$fundef_11_env_113" = type {}
+%"$$fundef_9_env_114" = type {}
+%"$$fundef_7_env_115" = type {}
+%Bool = type { i8, %True*, %False* }
+%True = type <{ i8 }>
+%False = type <{ i8 }>
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_40" = global %"$TyDescrTy_PrimTyp_39" zeroinitializer
+@"$TyDescr_Int32_41" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Int32_Prim_40" to i8*) }
+@"$TyDescr_Uint32_Prim_42" = global %"$TyDescrTy_PrimTyp_39" { i32 1, i32 0 }
+@"$TyDescr_Uint32_43" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Uint32_Prim_42" to i8*) }
+@"$TyDescr_Int64_Prim_44" = global %"$TyDescrTy_PrimTyp_39" { i32 0, i32 1 }
+@"$TyDescr_Int64_45" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Int64_Prim_44" to i8*) }
+@"$TyDescr_Uint64_Prim_46" = global %"$TyDescrTy_PrimTyp_39" { i32 1, i32 1 }
+@"$TyDescr_Uint64_47" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Uint64_Prim_46" to i8*) }
+@"$TyDescr_Int128_Prim_48" = global %"$TyDescrTy_PrimTyp_39" { i32 0, i32 2 }
+@"$TyDescr_Int128_49" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Int128_Prim_48" to i8*) }
+@"$TyDescr_Uint128_Prim_50" = global %"$TyDescrTy_PrimTyp_39" { i32 1, i32 2 }
+@"$TyDescr_Uint128_51" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Uint128_Prim_50" to i8*) }
+@"$TyDescr_Int256_Prim_52" = global %"$TyDescrTy_PrimTyp_39" { i32 0, i32 3 }
+@"$TyDescr_Int256_53" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Int256_Prim_52" to i8*) }
+@"$TyDescr_Uint256_Prim_54" = global %"$TyDescrTy_PrimTyp_39" { i32 1, i32 3 }
+@"$TyDescr_Uint256_55" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Uint256_Prim_54" to i8*) }
+@"$TyDescr_String_Prim_56" = global %"$TyDescrTy_PrimTyp_39" { i32 2, i32 0 }
+@"$TyDescr_String_57" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_String_Prim_56" to i8*) }
+@"$TyDescr_Bystr_Prim_58" = global %"$TyDescrTy_PrimTyp_39" { i32 7, i32 0 }
+@"$TyDescr_Bystr_59" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_39"* @"$TyDescr_Bystr_Prim_58" to i8*) }
+@"$TyDescr_ADT_Bool_63" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_60"* @"$TyDescr_Bool_ADTTyp_Specl_76" to i8*) }
+@"$TyDescr_ADT_List_Int64_64" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_60"* @"$TyDescr_List_Int64_ADTTyp_Specl_88" to i8*) }
+@"$TyDescr_ADT_List_Int32_65" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_60"* @"$TyDescr_List_Int32_ADTTyp_Specl_97" to i8*) }
+@"$TyDescr_Bool_ADTTyp_67" = unnamed_addr constant %"$TyDescrTy_ADTTyp_61" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Bool_78", i32 0, i32 0), i32 4 }, i32 0, i32 2, i32 1, %"$TyDescrTy_ADTTyp_Specl_60"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Specl_60"*], [1 x %"$TyDescrTy_ADTTyp_Specl_60"*]* @"$TyDescr_Bool_ADTTyp_m_specls_77", i32 0, i32 0) }
+@"$TyDescr_Bool_True_Constr_m_args_68" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_True_69" = unnamed_addr constant [4 x i8] c"True"
+@"$TyDescr_Bool_True_ADTTyp_Constr_70" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_62" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_True_69", i32 0, i32 0), i32 4 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_True_Constr_m_args_68", i32 0, i32 0) }
+@"$TyDescr_Bool_False_Constr_m_args_71" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_False_72" = unnamed_addr constant [5 x i8] c"False"
+@"$TyDescr_Bool_False_ADTTyp_Constr_73" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_62" { %TyDescrString { i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"$TyDescr_ADT_False_72", i32 0, i32 0), i32 5 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_False_Constr_m_args_71", i32 0, i32 0) }
+@"$TyDescr_Bool_ADTTyp_Specl_m_constrs_74" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_62"*] [%"$TyDescrTy_ADTTyp_Constr_62"* @"$TyDescr_Bool_True_ADTTyp_Constr_70", %"$TyDescrTy_ADTTyp_Constr_62"* @"$TyDescr_Bool_False_ADTTyp_Constr_73"]
+@"$TyDescr_Bool_ADTTyp_Specl_m_TArgs_75" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_Bool_ADTTyp_Specl_76" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_60" { %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_ADTTyp_Specl_m_TArgs_75", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_62"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_62"*], [2 x %"$TyDescrTy_ADTTyp_Constr_62"*]* @"$TyDescr_Bool_ADTTyp_Specl_m_constrs_74", i32 0, i32 0), %"$TyDescrTy_ADTTyp_61"* @"$TyDescr_Bool_ADTTyp_67" }
+@"$TyDescr_Bool_ADTTyp_m_specls_77" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Specl_60"*] [%"$TyDescrTy_ADTTyp_Specl_60"* @"$TyDescr_Bool_ADTTyp_Specl_76"]
+@"$TyDescr_ADT_Bool_78" = unnamed_addr constant [4 x i8] c"Bool"
+@"$TyDescr_List_ADTTyp_79" = unnamed_addr constant %"$TyDescrTy_ADTTyp_61" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_List_99", i32 0, i32 0), i32 4 }, i32 1, i32 2, i32 2, %"$TyDescrTy_ADTTyp_Specl_60"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Specl_60"*], [2 x %"$TyDescrTy_ADTTyp_Specl_60"*]* @"$TyDescr_List_ADTTyp_m_specls_98", i32 0, i32 0) }
+@"$TyDescr_List_Cons_Int64_Constr_m_args_80" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int64_45", %_TyDescrTy_Typ* @"$TyDescr_ADT_List_Int64_64"]
+@"$TyDescr_ADT_Cons_81" = unnamed_addr constant [4 x i8] c"Cons"
+@"$TyDescr_List_Cons_Int64_ADTTyp_Constr_82" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_62" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Cons_81", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Cons_Int64_Constr_m_args_80", i32 0, i32 0) }
+@"$TyDescr_List_Nil_Int64_Constr_m_args_83" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_Nil_84" = unnamed_addr constant [3 x i8] c"Nil"
+@"$TyDescr_List_Nil_Int64_ADTTyp_Constr_85" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_62" { %TyDescrString { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"$TyDescr_ADT_Nil_84", i32 0, i32 0), i32 3 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Nil_Int64_Constr_m_args_83", i32 0, i32 0) }
+@"$TyDescr_List_Int64_ADTTyp_Specl_m_constrs_86" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_62"*] [%"$TyDescrTy_ADTTyp_Constr_62"* @"$TyDescr_List_Cons_Int64_ADTTyp_Constr_82", %"$TyDescrTy_ADTTyp_Constr_62"* @"$TyDescr_List_Nil_Int64_ADTTyp_Constr_85"]
+@"$TyDescr_List_Int64_ADTTyp_Specl_m_TArgs_87" = unnamed_addr constant [1 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int64_45"]
+@"$TyDescr_List_Int64_ADTTyp_Specl_88" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_60" { %_TyDescrTy_Typ** getelementptr inbounds ([1 x %_TyDescrTy_Typ*], [1 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Int64_ADTTyp_Specl_m_TArgs_87", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_62"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_62"*], [2 x %"$TyDescrTy_ADTTyp_Constr_62"*]* @"$TyDescr_List_Int64_ADTTyp_Specl_m_constrs_86", i32 0, i32 0), %"$TyDescrTy_ADTTyp_61"* @"$TyDescr_List_ADTTyp_79" }
+@"$TyDescr_List_Cons_Int32_Constr_m_args_89" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int32_41", %_TyDescrTy_Typ* @"$TyDescr_ADT_List_Int32_65"]
+@"$TyDescr_ADT_Cons_90" = unnamed_addr constant [4 x i8] c"Cons"
+@"$TyDescr_List_Cons_Int32_ADTTyp_Constr_91" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_62" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Cons_90", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Cons_Int32_Constr_m_args_89", i32 0, i32 0) }
+@"$TyDescr_List_Nil_Int32_Constr_m_args_92" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_Nil_93" = unnamed_addr constant [3 x i8] c"Nil"
+@"$TyDescr_List_Nil_Int32_ADTTyp_Constr_94" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_62" { %TyDescrString { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"$TyDescr_ADT_Nil_93", i32 0, i32 0), i32 3 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Nil_Int32_Constr_m_args_92", i32 0, i32 0) }
+@"$TyDescr_List_Int32_ADTTyp_Specl_m_constrs_95" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_62"*] [%"$TyDescrTy_ADTTyp_Constr_62"* @"$TyDescr_List_Cons_Int32_ADTTyp_Constr_91", %"$TyDescrTy_ADTTyp_Constr_62"* @"$TyDescr_List_Nil_Int32_ADTTyp_Constr_94"]
+@"$TyDescr_List_Int32_ADTTyp_Specl_m_TArgs_96" = unnamed_addr constant [1 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int32_41"]
+@"$TyDescr_List_Int32_ADTTyp_Specl_97" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_60" { %_TyDescrTy_Typ** getelementptr inbounds ([1 x %_TyDescrTy_Typ*], [1 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Int32_ADTTyp_Specl_m_TArgs_96", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_62"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_62"*], [2 x %"$TyDescrTy_ADTTyp_Constr_62"*]* @"$TyDescr_List_Int32_ADTTyp_Specl_m_constrs_95", i32 0, i32 0), %"$TyDescrTy_ADTTyp_61"* @"$TyDescr_List_ADTTyp_79" }
+@"$TyDescr_List_ADTTyp_m_specls_98" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Specl_60"*] [%"$TyDescrTy_ADTTyp_Specl_60"* @"$TyDescr_List_Int64_ADTTyp_Specl_88", %"$TyDescrTy_ADTTyp_Specl_60"* @"$TyDescr_List_Int32_ADTTyp_Specl_97"]
+@"$TyDescr_ADT_List_99" = unnamed_addr constant [4 x i8] c"List"
+@"$dyndisp_223" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_230" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_237" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_244" = global [2 x { i8*, i8* }] zeroinitializer
+
+define internal { %TName_List_Int64* (i8*, %Int64)*, i8* } @"$fundef_37"(%"$$fundef_37_env_100"* %0, { i8*, i8* }* %1) {
+entry:
+  %"$retval_38" = alloca { %TName_List_Int64* (i8*, %Int64)*, i8* }
+  %"$f_209" = getelementptr { i8*, i8* }, { i8*, i8* }* %1, i32 1
+  %"$f_210" = bitcast { i8*, i8* }* %"$f_209" to { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }*
+  %"$f_211" = load { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }* %"$f_210"
+  %"$f_fptr_212" = extractvalue { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* } %"$f_211", 0
+  %"$f_envptr_213" = extractvalue { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* } %"$f_211", 1
+  %"$f_call_214" = call { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f_fptr_212"(i8* %"$f_envptr_213")
+  store { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f_call_214", { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_38"
+  %"$$retval_38_215" = load { %TName_List_Int64* (i8*, %Int64)*, i8* }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_38"
+  ret { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$$retval_38_215"
+}
+
+define internal { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } @"$fundef_35"(%"$$fundef_35_env_101"* %0) {
+entry:
+  %"$retval_36" = alloca { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  store { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)* bitcast ({ %TName_List_Int64* (i8*, %Int64)*, i8* } (%"$$fundef_37_env_100"*, { i8*, i8* }*)* @"$fundef_37" to { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*), i8* null }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_36"
+  %"$$retval_36_208" = load { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_36"
+  ret { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$retval_36_208"
+}
+
+define internal { %TName_List_Int32* (i8*, %Int32)*, i8* } @"$fundef_33"(%"$$fundef_33_env_102"* %0, { i8*, i8* }* %1) {
+entry:
+  %"$retval_34" = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  %"$f_198" = getelementptr { i8*, i8* }, { i8*, i8* }* %1, i32 0
+  %"$f_199" = bitcast { i8*, i8* }* %"$f_198" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }*
+  %"$f_200" = load { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }* %"$f_199"
+  %"$f_fptr_201" = extractvalue { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } %"$f_200", 0
+  %"$f_envptr_202" = extractvalue { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } %"$f_200", 1
+  %"$f_call_203" = call { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f_fptr_201"(i8* %"$f_envptr_202")
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f_call_203", { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_34"
+  %"$$retval_34_204" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_34"
+  ret { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$$retval_34_204"
+}
+
+define internal { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } @"$fundef_31"(%"$$fundef_31_env_103"* %0) {
+entry:
+  %"$retval_32" = alloca { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  store { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)* bitcast ({ %TName_List_Int32* (i8*, %Int32)*, i8* } (%"$$fundef_33_env_102"*, { i8*, i8* }*)* @"$fundef_33" to { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*), i8* null }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_32"
+  %"$$retval_32_197" = load { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_32"
+  ret { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$retval_32_197"
+}
+
+define internal %TName_List_Int64* @"$fundef_29"(%"$$fundef_29_env_104"* %0, %Int64 %1) {
+entry:
+  %"$retval_30" = alloca %TName_List_Int64*
+  %an = alloca %TName_List_Int64*
+  %"$adtval_178_load" = load i8*, i8** @_execptr
+  %"$adtval_178_salloc" = call i8* @_salloc(i8* %"$adtval_178_load", i64 1)
+  %"$adtval_178" = bitcast i8* %"$adtval_178_salloc" to %CName_Nil_Int64*
+  %"$adtgep_179" = getelementptr inbounds %CName_Nil_Int64, %CName_Nil_Int64* %"$adtval_178", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_179"
+  %"$adtptr_180" = bitcast %CName_Nil_Int64* %"$adtval_178" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_180", %TName_List_Int64** %an
+  %a1 = alloca %TName_List_Int64*
+  %"$an_181" = load %TName_List_Int64*, %TName_List_Int64** %an
+  %"$adtval_182_load" = load i8*, i8** @_execptr
+  %"$adtval_182_salloc" = call i8* @_salloc(i8* %"$adtval_182_load", i64 17)
+  %"$adtval_182" = bitcast i8* %"$adtval_182_salloc" to %CName_Cons_Int64*
+  %"$adtgep_183" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_182", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_183"
+  %"$adtgep_184" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_182", i32 0, i32 1
+  store %Int64 %1, %Int64* %"$adtgep_184"
+  %"$adtgep_185" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_182", i32 0, i32 2
+  store %TName_List_Int64* %"$an_181", %TName_List_Int64** %"$adtgep_185"
+  %"$adtptr_186" = bitcast %CName_Cons_Int64* %"$adtval_182" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_186", %TName_List_Int64** %a1
+  %"$a1_187" = load %TName_List_Int64*, %TName_List_Int64** %a1
+  %"$adtval_188_load" = load i8*, i8** @_execptr
+  %"$adtval_188_salloc" = call i8* @_salloc(i8* %"$adtval_188_load", i64 17)
+  %"$adtval_188" = bitcast i8* %"$adtval_188_salloc" to %CName_Cons_Int64*
+  %"$adtgep_189" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_188", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_189"
+  %"$adtgep_190" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_188", i32 0, i32 1
+  store %Int64 %1, %Int64* %"$adtgep_190"
+  %"$adtgep_191" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_188", i32 0, i32 2
+  store %TName_List_Int64* %"$a1_187", %TName_List_Int64** %"$adtgep_191"
+  %"$adtptr_192" = bitcast %CName_Cons_Int64* %"$adtval_188" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_192", %TName_List_Int64** %"$retval_30"
+  %"$$retval_30_193" = load %TName_List_Int64*, %TName_List_Int64** %"$retval_30"
+  ret %TName_List_Int64* %"$$retval_30_193"
+}
+
+define internal { %TName_List_Int64* (i8*, %Int64)*, i8* } @"$fundef_27"(%"$$fundef_27_env_105"* %0) {
+entry:
+  %"$retval_28" = alloca { %TName_List_Int64* (i8*, %Int64)*, i8* }
+  store { %TName_List_Int64* (i8*, %Int64)*, i8* } { %TName_List_Int64* (i8*, %Int64)* bitcast (%TName_List_Int64* (%"$$fundef_29_env_104"*, %Int64)* @"$fundef_29" to %TName_List_Int64* (i8*, %Int64)*), i8* null }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_28"
+  %"$$retval_28_177" = load { %TName_List_Int64* (i8*, %Int64)*, i8* }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_28"
+  ret { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$$retval_28_177"
+}
+
+define internal %TName_List_Int32* @"$fundef_25"(%"$$fundef_25_env_106"* %0, %Int32 %1) {
+entry:
+  %"$retval_26" = alloca %TName_List_Int32*
+  %an = alloca %TName_List_Int32*
+  %"$adtval_158_load" = load i8*, i8** @_execptr
+  %"$adtval_158_salloc" = call i8* @_salloc(i8* %"$adtval_158_load", i64 1)
+  %"$adtval_158" = bitcast i8* %"$adtval_158_salloc" to %CName_Nil_Int32*
+  %"$adtgep_159" = getelementptr inbounds %CName_Nil_Int32, %CName_Nil_Int32* %"$adtval_158", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_159"
+  %"$adtptr_160" = bitcast %CName_Nil_Int32* %"$adtval_158" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_160", %TName_List_Int32** %an
+  %a1 = alloca %TName_List_Int32*
+  %"$an_161" = load %TName_List_Int32*, %TName_List_Int32** %an
+  %"$adtval_162_load" = load i8*, i8** @_execptr
+  %"$adtval_162_salloc" = call i8* @_salloc(i8* %"$adtval_162_load", i64 13)
+  %"$adtval_162" = bitcast i8* %"$adtval_162_salloc" to %CName_Cons_Int32*
+  %"$adtgep_163" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_162", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_163"
+  %"$adtgep_164" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_162", i32 0, i32 1
+  store %Int32 %1, %Int32* %"$adtgep_164"
+  %"$adtgep_165" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_162", i32 0, i32 2
+  store %TName_List_Int32* %"$an_161", %TName_List_Int32** %"$adtgep_165"
+  %"$adtptr_166" = bitcast %CName_Cons_Int32* %"$adtval_162" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_166", %TName_List_Int32** %a1
+  %"$a1_167" = load %TName_List_Int32*, %TName_List_Int32** %a1
+  %"$adtval_168_load" = load i8*, i8** @_execptr
+  %"$adtval_168_salloc" = call i8* @_salloc(i8* %"$adtval_168_load", i64 13)
+  %"$adtval_168" = bitcast i8* %"$adtval_168_salloc" to %CName_Cons_Int32*
+  %"$adtgep_169" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_168", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_169"
+  %"$adtgep_170" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_168", i32 0, i32 1
+  store %Int32 %1, %Int32* %"$adtgep_170"
+  %"$adtgep_171" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_168", i32 0, i32 2
+  store %TName_List_Int32* %"$a1_167", %TName_List_Int32** %"$adtgep_171"
+  %"$adtptr_172" = bitcast %CName_Cons_Int32* %"$adtval_168" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_172", %TName_List_Int32** %"$retval_26"
+  %"$$retval_26_173" = load %TName_List_Int32*, %TName_List_Int32** %"$retval_26"
+  ret %TName_List_Int32* %"$$retval_26_173"
+}
+
+define internal { %TName_List_Int32* (i8*, %Int32)*, i8* } @"$fundef_23"(%"$$fundef_23_env_107"* %0) {
+entry:
+  %"$retval_24" = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } { %TName_List_Int32* (i8*, %Int32)* bitcast (%TName_List_Int32* (%"$$fundef_25_env_106"*, %Int32)* @"$fundef_25" to %TName_List_Int32* (i8*, %Int32)*), i8* null }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_24"
+  %"$$retval_24_157" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_24"
+  ret { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$$retval_24_157"
+}
+
+define internal %TName_List_Int64* @"$fundef_21"(%"$$fundef_21_env_108"* %0, %Int64 %1) {
+entry:
+  %"$retval_22" = alloca %TName_List_Int64*
+  %an = alloca %TName_List_Int64*
+  %"$adtval_144_load" = load i8*, i8** @_execptr
+  %"$adtval_144_salloc" = call i8* @_salloc(i8* %"$adtval_144_load", i64 1)
+  %"$adtval_144" = bitcast i8* %"$adtval_144_salloc" to %CName_Nil_Int64*
+  %"$adtgep_145" = getelementptr inbounds %CName_Nil_Int64, %CName_Nil_Int64* %"$adtval_144", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_145"
+  %"$adtptr_146" = bitcast %CName_Nil_Int64* %"$adtval_144" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_146", %TName_List_Int64** %an
+  %"$an_147" = load %TName_List_Int64*, %TName_List_Int64** %an
+  %"$adtval_148_load" = load i8*, i8** @_execptr
+  %"$adtval_148_salloc" = call i8* @_salloc(i8* %"$adtval_148_load", i64 17)
+  %"$adtval_148" = bitcast i8* %"$adtval_148_salloc" to %CName_Cons_Int64*
+  %"$adtgep_149" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_148", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_149"
+  %"$adtgep_150" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_148", i32 0, i32 1
+  store %Int64 %1, %Int64* %"$adtgep_150"
+  %"$adtgep_151" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_148", i32 0, i32 2
+  store %TName_List_Int64* %"$an_147", %TName_List_Int64** %"$adtgep_151"
+  %"$adtptr_152" = bitcast %CName_Cons_Int64* %"$adtval_148" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_152", %TName_List_Int64** %"$retval_22"
+  %"$$retval_22_153" = load %TName_List_Int64*, %TName_List_Int64** %"$retval_22"
+  ret %TName_List_Int64* %"$$retval_22_153"
+}
+
+define internal { %TName_List_Int64* (i8*, %Int64)*, i8* } @"$fundef_19"(%"$$fundef_19_env_109"* %0) {
+entry:
+  %"$retval_20" = alloca { %TName_List_Int64* (i8*, %Int64)*, i8* }
+  store { %TName_List_Int64* (i8*, %Int64)*, i8* } { %TName_List_Int64* (i8*, %Int64)* bitcast (%TName_List_Int64* (%"$$fundef_21_env_108"*, %Int64)* @"$fundef_21" to %TName_List_Int64* (i8*, %Int64)*), i8* null }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_20"
+  %"$$retval_20_143" = load { %TName_List_Int64* (i8*, %Int64)*, i8* }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_20"
+  ret { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$$retval_20_143"
+}
+
+define internal %TName_List_Int32* @"$fundef_17"(%"$$fundef_17_env_110"* %0, %Int32 %1) {
+entry:
+  %"$retval_18" = alloca %TName_List_Int32*
+  %an = alloca %TName_List_Int32*
+  %"$adtval_130_load" = load i8*, i8** @_execptr
+  %"$adtval_130_salloc" = call i8* @_salloc(i8* %"$adtval_130_load", i64 1)
+  %"$adtval_130" = bitcast i8* %"$adtval_130_salloc" to %CName_Nil_Int32*
+  %"$adtgep_131" = getelementptr inbounds %CName_Nil_Int32, %CName_Nil_Int32* %"$adtval_130", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_131"
+  %"$adtptr_132" = bitcast %CName_Nil_Int32* %"$adtval_130" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_132", %TName_List_Int32** %an
+  %"$an_133" = load %TName_List_Int32*, %TName_List_Int32** %an
+  %"$adtval_134_load" = load i8*, i8** @_execptr
+  %"$adtval_134_salloc" = call i8* @_salloc(i8* %"$adtval_134_load", i64 13)
+  %"$adtval_134" = bitcast i8* %"$adtval_134_salloc" to %CName_Cons_Int32*
+  %"$adtgep_135" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_134", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_135"
+  %"$adtgep_136" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_134", i32 0, i32 1
+  store %Int32 %1, %Int32* %"$adtgep_136"
+  %"$adtgep_137" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_134", i32 0, i32 2
+  store %TName_List_Int32* %"$an_133", %TName_List_Int32** %"$adtgep_137"
+  %"$adtptr_138" = bitcast %CName_Cons_Int32* %"$adtval_134" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_138", %TName_List_Int32** %"$retval_18"
+  %"$$retval_18_139" = load %TName_List_Int32*, %TName_List_Int32** %"$retval_18"
+  ret %TName_List_Int32* %"$$retval_18_139"
+}
+
+define internal { %TName_List_Int32* (i8*, %Int32)*, i8* } @"$fundef_15"(%"$$fundef_15_env_111"* %0) {
+entry:
+  %"$retval_16" = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } { %TName_List_Int32* (i8*, %Int32)* bitcast (%TName_List_Int32* (%"$$fundef_17_env_110"*, %Int32)* @"$fundef_17" to %TName_List_Int32* (i8*, %Int32)*), i8* null }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_16"
+  %"$$retval_16_129" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_16"
+  ret { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$$retval_16_129"
+}
+
+define internal %Int32 @"$fundef_13"(%"$$fundef_13_env_112"* %0, %TName_List_Int64* %1) {
+entry:
+  %"$retval_14" = alloca %Int32
+  store %Int32 zeroinitializer, %Int32* %"$retval_14"
+  %"$$retval_14_125" = load %Int32, %Int32* %"$retval_14"
+  ret %Int32 %"$$retval_14_125"
+}
+
+define internal { %Int32 (i8*, %TName_List_Int64*)*, i8* } @"$fundef_11"(%"$$fundef_11_env_113"* %0) {
+entry:
+  %"$retval_12" = alloca { %Int32 (i8*, %TName_List_Int64*)*, i8* }
+  store { %Int32 (i8*, %TName_List_Int64*)*, i8* } { %Int32 (i8*, %TName_List_Int64*)* bitcast (%Int32 (%"$$fundef_13_env_112"*, %TName_List_Int64*)* @"$fundef_13" to %Int32 (i8*, %TName_List_Int64*)*), i8* null }, { %Int32 (i8*, %TName_List_Int64*)*, i8* }* %"$retval_12"
+  %"$$retval_12_124" = load { %Int32 (i8*, %TName_List_Int64*)*, i8* }, { %Int32 (i8*, %TName_List_Int64*)*, i8* }* %"$retval_12"
+  ret { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$$retval_12_124"
+}
+
+define internal %Int32 @"$fundef_9"(%"$$fundef_9_env_114"* %0, %TName_List_Int32* %1) {
+entry:
+  %"$retval_10" = alloca %Int32
+  store %Int32 zeroinitializer, %Int32* %"$retval_10"
+  %"$$retval_10_120" = load %Int32, %Int32* %"$retval_10"
+  ret %Int32 %"$$retval_10_120"
+}
+
+define internal { %Int32 (i8*, %TName_List_Int32*)*, i8* } @"$fundef_7"(%"$$fundef_7_env_115"* %0) {
+entry:
+  %"$retval_8" = alloca { %Int32 (i8*, %TName_List_Int32*)*, i8* }
+  store { %Int32 (i8*, %TName_List_Int32*)*, i8* } { %Int32 (i8*, %TName_List_Int32*)* bitcast (%Int32 (%"$$fundef_9_env_114"*, %TName_List_Int32*)* @"$fundef_9" to %Int32 (i8*, %TName_List_Int32*)*), i8* null }, { %Int32 (i8*, %TName_List_Int32*)*, i8* }* %"$retval_8"
+  %"$$retval_8_119" = load { %Int32 (i8*, %TName_List_Int32*)*, i8* }, { %Int32 (i8*, %TName_List_Int32*)*, i8* }* %"$retval_8"
+  ret { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$$retval_8_119"
+}
+
+declare i8* @_salloc(i8*, i64)
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal %Int32 @"$scilla_expr_216"(i8* %0) {
+entry:
+  %"$expr_6" = alloca %Int32
+  %list_length_dummy = alloca { i8*, i8* }*
+  store { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* } { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)* bitcast ({ %Int32 (i8*, %TName_List_Int32*)*, i8* } (%"$$fundef_7_env_115"*)* @"$fundef_7" to { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*), i8* null }, { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_223" to { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }*)
+  store { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* } { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)* bitcast ({ %Int32 (i8*, %TName_List_Int64*)*, i8* } (%"$$fundef_11_env_113"*)* @"$fundef_11" to { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*), i8* null }, { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_223", i32 0, i32 1) to { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_223", i32 0, i32 0), { i8*, i8* }** %list_length_dummy
+  %t1 = alloca { i8*, i8* }*
+  store { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)* bitcast ({ %TName_List_Int32* (i8*, %Int32)*, i8* } (%"$$fundef_15_env_111"*)* @"$fundef_15" to { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*), i8* null }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_230" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }*)
+  store { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* } { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)* bitcast ({ %TName_List_Int64* (i8*, %Int64)*, i8* } (%"$$fundef_19_env_109"*)* @"$fundef_19" to { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*), i8* null }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_230", i32 0, i32 1) to { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_230", i32 0, i32 0), { i8*, i8* }** %t1
+  %t2 = alloca { i8*, i8* }*
+  store { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)* bitcast ({ %TName_List_Int32* (i8*, %Int32)*, i8* } (%"$$fundef_23_env_107"*)* @"$fundef_23" to { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*), i8* null }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_237" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }*)
+  store { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* } { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)* bitcast ({ %TName_List_Int64* (i8*, %Int64)*, i8* } (%"$$fundef_27_env_105"*)* @"$fundef_27" to { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*), i8* null }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_237", i32 0, i32 1) to { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_237", i32 0, i32 0), { i8*, i8* }** %t2
+  %t = alloca { i8*, i8* }*
+  store { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)* bitcast ({ { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (%"$$fundef_31_env_103"*)* @"$fundef_31" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*), i8* null }, { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_244" to { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }*)
+  store { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)* bitcast ({ { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (%"$$fundef_35_env_101"*)* @"$fundef_35" to { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*), i8* null }, { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_244", i32 0, i32 1) to { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_244", i32 0, i32 0), { i8*, i8* }** %t
+  %some_bool = alloca %Bool*
+  %"$adtval_245_load" = load i8*, i8** @_execptr
+  %"$adtval_245_salloc" = call i8* @_salloc(i8* %"$adtval_245_load", i64 1)
+  %"$adtval_245" = bitcast i8* %"$adtval_245_salloc" to %False*
+  %"$adtgep_246" = getelementptr inbounds %False, %False* %"$adtval_245", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_246"
+  %"$adtptr_247" = bitcast %False* %"$adtval_245" to %Bool*
+  store %Bool* %"$adtptr_247", %Bool** %some_bool
+  %"$some_bool_249" = load %Bool*, %Bool** %some_bool
+  %"$some_bool_tag_250" = getelementptr inbounds %Bool, %Bool* %"$some_bool_249", i32 0, i32 0
+  %"$some_bool_tag_251" = load i8, i8* %"$some_bool_tag_250"
+  switch i8 %"$some_bool_tag_251", label %"$empty_default_252" [
+    i8 0, label %"$True_253"
+    i8 1, label %"$False_287"
+  ]
+
+"$True_253":                                      ; preds = %entry
+  %"$some_bool_254" = bitcast %Bool* %"$some_bool_249" to %True*
+  %f11 = alloca { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  %"$t_255" = load { i8*, i8* }*, { i8*, i8* }** %t
+  %"$t_256" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$t_255", i32 0
+  %"$t_257" = bitcast { i8*, i8* }* %"$t_256" to { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }*
+  %"$t_258" = load { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }, { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }* %"$t_257"
+  %"$t_fptr_259" = extractvalue { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } %"$t_258", 0
+  %"$t_envptr_260" = extractvalue { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } %"$t_258", 1
+  %"$t_call_261" = call { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_fptr_259"(i8* %"$t_envptr_260")
+  store { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_call_261", { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %f11
+  %f1 = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  %"$f11_0" = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  %"$f11_262" = load { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %f11
+  %"$f11_fptr_263" = extractvalue { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$f11_262", 0
+  %"$f11_envptr_264" = extractvalue { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$f11_262", 1
+  %"$t1_265" = load { i8*, i8* }*, { i8*, i8* }** %t1
+  %"$f11_call_266" = call { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f11_fptr_263"(i8* %"$f11_envptr_264", { i8*, i8* }* %"$t1_265")
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f11_call_266", { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$f11_0"
+  %"$$f11_0_267" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$f11_0"
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$$f11_0_267", { %TName_List_Int32* (i8*, %Int32)*, i8* }* %f1
+  %len = alloca { %Int32 (i8*, %TName_List_Int32*)*, i8* }
+  %"$list_length_dummy_268" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  %"$list_length_dummy_269" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$list_length_dummy_268", i32 0
+  %"$list_length_dummy_270" = bitcast { i8*, i8* }* %"$list_length_dummy_269" to { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }*
+  %"$list_length_dummy_271" = load { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }, { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }* %"$list_length_dummy_270"
+  %"$list_length_dummy_fptr_272" = extractvalue { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_271", 0
+  %"$list_length_dummy_envptr_273" = extractvalue { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_271", 1
+  %"$list_length_dummy_call_274" = call { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$list_length_dummy_fptr_272"(i8* %"$list_length_dummy_envptr_273")
+  store { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$list_length_dummy_call_274", { %Int32 (i8*, %TName_List_Int32*)*, i8* }* %len
+  %one = alloca %Int32
+  store %Int32 { i32 1 }, %Int32* %one
+  %f1l = alloca %TName_List_Int32*
+  %"$f1_1" = alloca %TName_List_Int32*
+  %"$f1_275" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %f1
+  %"$f1_fptr_276" = extractvalue { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f1_275", 0
+  %"$f1_envptr_277" = extractvalue { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f1_275", 1
+  %"$one_278" = load %Int32, %Int32* %one
+  %"$f1_call_279" = call %TName_List_Int32* %"$f1_fptr_276"(i8* %"$f1_envptr_277", %Int32 %"$one_278")
+  store %TName_List_Int32* %"$f1_call_279", %TName_List_Int32** %"$f1_1"
+  %"$$f1_1_280" = load %TName_List_Int32*, %TName_List_Int32** %"$f1_1"
+  store %TName_List_Int32* %"$$f1_1_280", %TName_List_Int32** %f1l
+  %"$len_2" = alloca %Int32
+  %"$len_281" = load { %Int32 (i8*, %TName_List_Int32*)*, i8* }, { %Int32 (i8*, %TName_List_Int32*)*, i8* }* %len
+  %"$len_fptr_282" = extractvalue { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$len_281", 0
+  %"$len_envptr_283" = extractvalue { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$len_281", 1
+  %"$f1l_284" = load %TName_List_Int32*, %TName_List_Int32** %f1l
+  %"$len_call_285" = call %Int32 %"$len_fptr_282"(i8* %"$len_envptr_283", %TName_List_Int32* %"$f1l_284")
+  store %Int32 %"$len_call_285", %Int32* %"$len_2"
+  %"$$len_2_286" = load %Int32, %Int32* %"$len_2"
+  store %Int32 %"$$len_2_286", %Int32* %"$expr_6"
+  br label %"$matchsucc_248"
+
+"$False_287":                                     ; preds = %entry
+  %"$some_bool_288" = bitcast %Bool* %"$some_bool_249" to %False*
+  %f22 = alloca { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  %"$t_289" = load { i8*, i8* }*, { i8*, i8* }** %t
+  %"$t_290" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$t_289", i32 1
+  %"$t_291" = bitcast { i8*, i8* }* %"$t_290" to { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }*
+  %"$t_292" = load { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }, { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }* %"$t_291"
+  %"$t_fptr_293" = extractvalue { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } %"$t_292", 0
+  %"$t_envptr_294" = extractvalue { { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } %"$t_292", 1
+  %"$t_call_295" = call { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_fptr_293"(i8* %"$t_envptr_294")
+  store { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_call_295", { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %f22
+  %f2 = alloca { %TName_List_Int64* (i8*, %Int64)*, i8* }
+  %"$f22_3" = alloca { %TName_List_Int64* (i8*, %Int64)*, i8* }
+  %"$f22_296" = load { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %f22
+  %"$f22_fptr_297" = extractvalue { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$f22_296", 0
+  %"$f22_envptr_298" = extractvalue { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$f22_296", 1
+  %"$t2_299" = load { i8*, i8* }*, { i8*, i8* }** %t2
+  %"$f22_call_300" = call { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f22_fptr_297"(i8* %"$f22_envptr_298", { i8*, i8* }* %"$t2_299")
+  store { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f22_call_300", { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$f22_3"
+  %"$$f22_3_301" = load { %TName_List_Int64* (i8*, %Int64)*, i8* }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$f22_3"
+  store { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$$f22_3_301", { %TName_List_Int64* (i8*, %Int64)*, i8* }* %f2
+  %len1 = alloca { %Int32 (i8*, %TName_List_Int64*)*, i8* }
+  %"$list_length_dummy_302" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  %"$list_length_dummy_303" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$list_length_dummy_302", i32 1
+  %"$list_length_dummy_304" = bitcast { i8*, i8* }* %"$list_length_dummy_303" to { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }*
+  %"$list_length_dummy_305" = load { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }, { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }* %"$list_length_dummy_304"
+  %"$list_length_dummy_fptr_306" = extractvalue { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_305", 0
+  %"$list_length_dummy_envptr_307" = extractvalue { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_305", 1
+  %"$list_length_dummy_call_308" = call { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$list_length_dummy_fptr_306"(i8* %"$list_length_dummy_envptr_307")
+  store { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$list_length_dummy_call_308", { %Int32 (i8*, %TName_List_Int64*)*, i8* }* %len1
+  %one2 = alloca %Int64
+  store %Int64 { i64 1 }, %Int64* %one2
+  %f2l = alloca %TName_List_Int64*
+  %"$f2_4" = alloca %TName_List_Int64*
+  %"$f2_309" = load { %TName_List_Int64* (i8*, %Int64)*, i8* }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %f2
+  %"$f2_fptr_310" = extractvalue { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f2_309", 0
+  %"$f2_envptr_311" = extractvalue { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f2_309", 1
+  %"$one_312" = load %Int64, %Int64* %one2
+  %"$f2_call_313" = call %TName_List_Int64* %"$f2_fptr_310"(i8* %"$f2_envptr_311", %Int64 %"$one_312")
+  store %TName_List_Int64* %"$f2_call_313", %TName_List_Int64** %"$f2_4"
+  %"$$f2_4_314" = load %TName_List_Int64*, %TName_List_Int64** %"$f2_4"
+  store %TName_List_Int64* %"$$f2_4_314", %TName_List_Int64** %f2l
+  %"$len_5" = alloca %Int32
+  %"$len_315" = load { %Int32 (i8*, %TName_List_Int64*)*, i8* }, { %Int32 (i8*, %TName_List_Int64*)*, i8* }* %len1
+  %"$len_fptr_316" = extractvalue { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$len_315", 0
+  %"$len_envptr_317" = extractvalue { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$len_315", 1
+  %"$f2l_318" = load %TName_List_Int64*, %TName_List_Int64** %f2l
+  %"$len_call_319" = call %Int32 %"$len_fptr_316"(i8* %"$len_envptr_317", %TName_List_Int64* %"$f2l_318")
+  store %Int32 %"$len_call_319", %Int32* %"$len_5"
+  %"$$len_5_320" = load %Int32, %Int32* %"$len_5"
+  store %Int32 %"$$len_5_320", %Int32* %"$expr_6"
+  br label %"$matchsucc_248"
+
+"$empty_default_252":                             ; preds = %entry
+  br label %"$matchsucc_248"
+
+"$matchsucc_248":                                 ; preds = %"$False_287", %"$True_253", %"$empty_default_252"
+  %"$$expr_6_321" = load %Int32, %Int32* %"$expr_6"
+  ret %Int32 %"$$expr_6_321"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$exprval_322" = call %Int32 @"$scilla_expr_216"(i8* null)
+  %"$pval_323" = alloca %Int32
+  %"$memvoidcast_324" = bitcast %Int32* %"$pval_323" to i8*
+  store %Int32 %"$exprval_322", %Int32* %"$pval_323"
+  call void @_print_scilla_val(%_TyDescrTy_Typ* @"$TyDescr_Int32_41", i8* %"$memvoidcast_324")
+  ret void
+}

--- a/tests/codegen/expr/gold/multi-type-inst.scilexp.gold
+++ b/tests/codegen/expr/gold/multi-type-inst.scilexp.gold
@@ -1,8 +1,470 @@
-Specializing [codegen/expr/multi-type-inst.scilexp:2:8] 'A with Int32
-Specializing [codegen/expr/multi-type-inst.scilexp:2:8] 'A with Int64
-Specializing [codegen/expr/multi-type-inst.scilexp:9:8] 'A with Int32
-Specializing [codegen/expr/multi-type-inst.scilexp:9:8] 'A with Int64
-Specializing [codegen/expr/multi-type-inst.scilexp:16:8] 'A with Int32
-Specializing [codegen/expr/multi-type-inst.scilexp:16:8] 'A with Int64
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_29" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$TyDescrTy_ADTTyp_51" = type { %TyDescrString, i32, i32, i32, %"$TyDescrTy_ADTTyp_Specl_50"** }
+%TyDescrString = type { i8*, i32 }
+%"$TyDescrTy_ADTTyp_Specl_50" = type { %_TyDescrTy_Typ**, %"$TyDescrTy_ADTTyp_Constr_52"**, %"$TyDescrTy_ADTTyp_51"* }
+%"$TyDescrTy_ADTTyp_Constr_52" = type { %TyDescrString, i32, %_TyDescrTy_Typ** }
+%TName_List_Int64 = type { i8, %CName_Cons_Int64*, %CName_Nil_Int64* }
+%CName_Cons_Int64 = type <{ i8, %Int64, %TName_List_Int64* }>
+%CName_Nil_Int64 = type <{ i8 }>
+%"$$fundef_27_env_90" = type {}
+%Int64 = type { i64 }
+%"$$fundef_25_env_91" = type {}
+%TName_List_Int32 = type { i8, %CName_Cons_Int32*, %CName_Nil_Int32* }
+%CName_Cons_Int32 = type <{ i8, %Int32, %TName_List_Int32* }>
+%CName_Nil_Int32 = type <{ i8 }>
+%"$$fundef_23_env_92" = type {}
+%Int32 = type { i32 }
+%"$$fundef_21_env_93" = type {}
+%"$$fundef_19_env_94" = type {}
+%"$$fundef_17_env_95" = type {}
+%"$$fundef_15_env_96" = type {}
+%"$$fundef_13_env_97" = type {}
+%"$$fundef_11_env_98" = type {}
+%"$$fundef_9_env_99" = type {}
+%"$$fundef_7_env_100" = type {}
+%"$$fundef_5_env_101" = type {}
+%Bool = type { i8, %True*, %False* }
+%True = type <{ i8 }>
+%False = type <{ i8 }>
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_30" = global %"$TyDescrTy_PrimTyp_29" zeroinitializer
+@"$TyDescr_Int32_31" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int32_Prim_30" to i8*) }
+@"$TyDescr_Uint32_Prim_32" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 0 }
+@"$TyDescr_Uint32_33" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint32_Prim_32" to i8*) }
+@"$TyDescr_Int64_Prim_34" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 1 }
+@"$TyDescr_Int64_35" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int64_Prim_34" to i8*) }
+@"$TyDescr_Uint64_Prim_36" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 1 }
+@"$TyDescr_Uint64_37" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint64_Prim_36" to i8*) }
+@"$TyDescr_Int128_Prim_38" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 2 }
+@"$TyDescr_Int128_39" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int128_Prim_38" to i8*) }
+@"$TyDescr_Uint128_Prim_40" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 2 }
+@"$TyDescr_Uint128_41" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint128_Prim_40" to i8*) }
+@"$TyDescr_Int256_Prim_42" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 3 }
+@"$TyDescr_Int256_43" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int256_Prim_42" to i8*) }
+@"$TyDescr_Uint256_Prim_44" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 3 }
+@"$TyDescr_Uint256_45" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint256_Prim_44" to i8*) }
+@"$TyDescr_String_Prim_46" = global %"$TyDescrTy_PrimTyp_29" { i32 2, i32 0 }
+@"$TyDescr_String_47" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_String_Prim_46" to i8*) }
+@"$TyDescr_Bystr_Prim_48" = global %"$TyDescrTy_PrimTyp_29" { i32 7, i32 0 }
+@"$TyDescr_Bystr_49" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Bystr_Prim_48" to i8*) }
+@"$TyDescr_ADT_Bool_53" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_50"* @"$TyDescr_Bool_ADTTyp_Specl_66" to i8*) }
+@"$TyDescr_ADT_List_Int64_54" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_50"* @"$TyDescr_List_Int64_ADTTyp_Specl_78" to i8*) }
+@"$TyDescr_ADT_List_Int32_55" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_50"* @"$TyDescr_List_Int32_ADTTyp_Specl_87" to i8*) }
+@"$TyDescr_Bool_ADTTyp_57" = unnamed_addr constant %"$TyDescrTy_ADTTyp_51" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Bool_68", i32 0, i32 0), i32 4 }, i32 0, i32 2, i32 1, %"$TyDescrTy_ADTTyp_Specl_50"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Specl_50"*], [1 x %"$TyDescrTy_ADTTyp_Specl_50"*]* @"$TyDescr_Bool_ADTTyp_m_specls_67", i32 0, i32 0) }
+@"$TyDescr_Bool_True_Constr_m_args_58" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_True_59" = unnamed_addr constant [4 x i8] c"True"
+@"$TyDescr_Bool_True_ADTTyp_Constr_60" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_52" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_True_59", i32 0, i32 0), i32 4 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_True_Constr_m_args_58", i32 0, i32 0) }
+@"$TyDescr_Bool_False_Constr_m_args_61" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_False_62" = unnamed_addr constant [5 x i8] c"False"
+@"$TyDescr_Bool_False_ADTTyp_Constr_63" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_52" { %TyDescrString { i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"$TyDescr_ADT_False_62", i32 0, i32 0), i32 5 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_False_Constr_m_args_61", i32 0, i32 0) }
+@"$TyDescr_Bool_ADTTyp_Specl_m_constrs_64" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_52"*] [%"$TyDescrTy_ADTTyp_Constr_52"* @"$TyDescr_Bool_True_ADTTyp_Constr_60", %"$TyDescrTy_ADTTyp_Constr_52"* @"$TyDescr_Bool_False_ADTTyp_Constr_63"]
+@"$TyDescr_Bool_ADTTyp_Specl_m_TArgs_65" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_Bool_ADTTyp_Specl_66" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_50" { %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_ADTTyp_Specl_m_TArgs_65", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_52"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_52"*], [2 x %"$TyDescrTy_ADTTyp_Constr_52"*]* @"$TyDescr_Bool_ADTTyp_Specl_m_constrs_64", i32 0, i32 0), %"$TyDescrTy_ADTTyp_51"* @"$TyDescr_Bool_ADTTyp_57" }
+@"$TyDescr_Bool_ADTTyp_m_specls_67" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Specl_50"*] [%"$TyDescrTy_ADTTyp_Specl_50"* @"$TyDescr_Bool_ADTTyp_Specl_66"]
+@"$TyDescr_ADT_Bool_68" = unnamed_addr constant [4 x i8] c"Bool"
+@"$TyDescr_List_ADTTyp_69" = unnamed_addr constant %"$TyDescrTy_ADTTyp_51" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_List_89", i32 0, i32 0), i32 4 }, i32 1, i32 2, i32 2, %"$TyDescrTy_ADTTyp_Specl_50"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Specl_50"*], [2 x %"$TyDescrTy_ADTTyp_Specl_50"*]* @"$TyDescr_List_ADTTyp_m_specls_88", i32 0, i32 0) }
+@"$TyDescr_List_Cons_Int64_Constr_m_args_70" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int64_35", %_TyDescrTy_Typ* @"$TyDescr_ADT_List_Int64_54"]
+@"$TyDescr_ADT_Cons_71" = unnamed_addr constant [4 x i8] c"Cons"
+@"$TyDescr_List_Cons_Int64_ADTTyp_Constr_72" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_52" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Cons_71", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Cons_Int64_Constr_m_args_70", i32 0, i32 0) }
+@"$TyDescr_List_Nil_Int64_Constr_m_args_73" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_Nil_74" = unnamed_addr constant [3 x i8] c"Nil"
+@"$TyDescr_List_Nil_Int64_ADTTyp_Constr_75" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_52" { %TyDescrString { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"$TyDescr_ADT_Nil_74", i32 0, i32 0), i32 3 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Nil_Int64_Constr_m_args_73", i32 0, i32 0) }
+@"$TyDescr_List_Int64_ADTTyp_Specl_m_constrs_76" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_52"*] [%"$TyDescrTy_ADTTyp_Constr_52"* @"$TyDescr_List_Cons_Int64_ADTTyp_Constr_72", %"$TyDescrTy_ADTTyp_Constr_52"* @"$TyDescr_List_Nil_Int64_ADTTyp_Constr_75"]
+@"$TyDescr_List_Int64_ADTTyp_Specl_m_TArgs_77" = unnamed_addr constant [1 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int64_35"]
+@"$TyDescr_List_Int64_ADTTyp_Specl_78" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_50" { %_TyDescrTy_Typ** getelementptr inbounds ([1 x %_TyDescrTy_Typ*], [1 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Int64_ADTTyp_Specl_m_TArgs_77", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_52"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_52"*], [2 x %"$TyDescrTy_ADTTyp_Constr_52"*]* @"$TyDescr_List_Int64_ADTTyp_Specl_m_constrs_76", i32 0, i32 0), %"$TyDescrTy_ADTTyp_51"* @"$TyDescr_List_ADTTyp_69" }
+@"$TyDescr_List_Cons_Int32_Constr_m_args_79" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int32_31", %_TyDescrTy_Typ* @"$TyDescr_ADT_List_Int32_55"]
+@"$TyDescr_ADT_Cons_80" = unnamed_addr constant [4 x i8] c"Cons"
+@"$TyDescr_List_Cons_Int32_ADTTyp_Constr_81" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_52" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Cons_80", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Cons_Int32_Constr_m_args_79", i32 0, i32 0) }
+@"$TyDescr_List_Nil_Int32_Constr_m_args_82" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_Nil_83" = unnamed_addr constant [3 x i8] c"Nil"
+@"$TyDescr_List_Nil_Int32_ADTTyp_Constr_84" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_52" { %TyDescrString { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"$TyDescr_ADT_Nil_83", i32 0, i32 0), i32 3 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Nil_Int32_Constr_m_args_82", i32 0, i32 0) }
+@"$TyDescr_List_Int32_ADTTyp_Specl_m_constrs_85" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_52"*] [%"$TyDescrTy_ADTTyp_Constr_52"* @"$TyDescr_List_Cons_Int32_ADTTyp_Constr_81", %"$TyDescrTy_ADTTyp_Constr_52"* @"$TyDescr_List_Nil_Int32_ADTTyp_Constr_84"]
+@"$TyDescr_List_Int32_ADTTyp_Specl_m_TArgs_86" = unnamed_addr constant [1 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int32_31"]
+@"$TyDescr_List_Int32_ADTTyp_Specl_87" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_50" { %_TyDescrTy_Typ** getelementptr inbounds ([1 x %_TyDescrTy_Typ*], [1 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Int32_ADTTyp_Specl_m_TArgs_86", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_52"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_52"*], [2 x %"$TyDescrTy_ADTTyp_Constr_52"*]* @"$TyDescr_List_Int32_ADTTyp_Specl_m_constrs_85", i32 0, i32 0), %"$TyDescrTy_ADTTyp_51"* @"$TyDescr_List_ADTTyp_69" }
+@"$TyDescr_List_ADTTyp_m_specls_88" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Specl_50"*] [%"$TyDescrTy_ADTTyp_Specl_50"* @"$TyDescr_List_Int64_ADTTyp_Specl_78", %"$TyDescrTy_ADTTyp_Specl_50"* @"$TyDescr_List_Int32_ADTTyp_Specl_87"]
+@"$TyDescr_ADT_List_89" = unnamed_addr constant [4 x i8] c"List"
+@"$dyndisp_187" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_194" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_201" = global [2 x { i8*, i8* }] zeroinitializer
+
+define internal %TName_List_Int64* @"$fundef_27"(%"$$fundef_27_env_90"* %0, %Int64 %1) {
+entry:
+  %"$retval_28" = alloca %TName_List_Int64*
+  %an = alloca %TName_List_Int64*
+  %"$adtval_164_load" = load i8*, i8** @_execptr
+  %"$adtval_164_salloc" = call i8* @_salloc(i8* %"$adtval_164_load", i64 1)
+  %"$adtval_164" = bitcast i8* %"$adtval_164_salloc" to %CName_Nil_Int64*
+  %"$adtgep_165" = getelementptr inbounds %CName_Nil_Int64, %CName_Nil_Int64* %"$adtval_164", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_165"
+  %"$adtptr_166" = bitcast %CName_Nil_Int64* %"$adtval_164" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_166", %TName_List_Int64** %an
+  %a1 = alloca %TName_List_Int64*
+  %"$an_167" = load %TName_List_Int64*, %TName_List_Int64** %an
+  %"$adtval_168_load" = load i8*, i8** @_execptr
+  %"$adtval_168_salloc" = call i8* @_salloc(i8* %"$adtval_168_load", i64 17)
+  %"$adtval_168" = bitcast i8* %"$adtval_168_salloc" to %CName_Cons_Int64*
+  %"$adtgep_169" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_168", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_169"
+  %"$adtgep_170" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_168", i32 0, i32 1
+  store %Int64 %1, %Int64* %"$adtgep_170"
+  %"$adtgep_171" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_168", i32 0, i32 2
+  store %TName_List_Int64* %"$an_167", %TName_List_Int64** %"$adtgep_171"
+  %"$adtptr_172" = bitcast %CName_Cons_Int64* %"$adtval_168" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_172", %TName_List_Int64** %a1
+  %"$a1_173" = load %TName_List_Int64*, %TName_List_Int64** %a1
+  %"$adtval_174_load" = load i8*, i8** @_execptr
+  %"$adtval_174_salloc" = call i8* @_salloc(i8* %"$adtval_174_load", i64 17)
+  %"$adtval_174" = bitcast i8* %"$adtval_174_salloc" to %CName_Cons_Int64*
+  %"$adtgep_175" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_174", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_175"
+  %"$adtgep_176" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_174", i32 0, i32 1
+  store %Int64 %1, %Int64* %"$adtgep_176"
+  %"$adtgep_177" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_174", i32 0, i32 2
+  store %TName_List_Int64* %"$a1_173", %TName_List_Int64** %"$adtgep_177"
+  %"$adtptr_178" = bitcast %CName_Cons_Int64* %"$adtval_174" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_178", %TName_List_Int64** %"$retval_28"
+  %"$$retval_28_179" = load %TName_List_Int64*, %TName_List_Int64** %"$retval_28"
+  ret %TName_List_Int64* %"$$retval_28_179"
+}
+
+define internal { %TName_List_Int64* (i8*, %Int64)*, i8* } @"$fundef_25"(%"$$fundef_25_env_91"* %0) {
+entry:
+  %"$retval_26" = alloca { %TName_List_Int64* (i8*, %Int64)*, i8* }
+  store { %TName_List_Int64* (i8*, %Int64)*, i8* } { %TName_List_Int64* (i8*, %Int64)* bitcast (%TName_List_Int64* (%"$$fundef_27_env_90"*, %Int64)* @"$fundef_27" to %TName_List_Int64* (i8*, %Int64)*), i8* null }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_26"
+  %"$$retval_26_163" = load { %TName_List_Int64* (i8*, %Int64)*, i8* }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_26"
+  ret { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$$retval_26_163"
+}
+
+define internal %TName_List_Int32* @"$fundef_23"(%"$$fundef_23_env_92"* %0, %Int32 %1) {
+entry:
+  %"$retval_24" = alloca %TName_List_Int32*
+  %an = alloca %TName_List_Int32*
+  %"$adtval_144_load" = load i8*, i8** @_execptr
+  %"$adtval_144_salloc" = call i8* @_salloc(i8* %"$adtval_144_load", i64 1)
+  %"$adtval_144" = bitcast i8* %"$adtval_144_salloc" to %CName_Nil_Int32*
+  %"$adtgep_145" = getelementptr inbounds %CName_Nil_Int32, %CName_Nil_Int32* %"$adtval_144", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_145"
+  %"$adtptr_146" = bitcast %CName_Nil_Int32* %"$adtval_144" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_146", %TName_List_Int32** %an
+  %a1 = alloca %TName_List_Int32*
+  %"$an_147" = load %TName_List_Int32*, %TName_List_Int32** %an
+  %"$adtval_148_load" = load i8*, i8** @_execptr
+  %"$adtval_148_salloc" = call i8* @_salloc(i8* %"$adtval_148_load", i64 13)
+  %"$adtval_148" = bitcast i8* %"$adtval_148_salloc" to %CName_Cons_Int32*
+  %"$adtgep_149" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_148", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_149"
+  %"$adtgep_150" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_148", i32 0, i32 1
+  store %Int32 %1, %Int32* %"$adtgep_150"
+  %"$adtgep_151" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_148", i32 0, i32 2
+  store %TName_List_Int32* %"$an_147", %TName_List_Int32** %"$adtgep_151"
+  %"$adtptr_152" = bitcast %CName_Cons_Int32* %"$adtval_148" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_152", %TName_List_Int32** %a1
+  %"$a1_153" = load %TName_List_Int32*, %TName_List_Int32** %a1
+  %"$adtval_154_load" = load i8*, i8** @_execptr
+  %"$adtval_154_salloc" = call i8* @_salloc(i8* %"$adtval_154_load", i64 13)
+  %"$adtval_154" = bitcast i8* %"$adtval_154_salloc" to %CName_Cons_Int32*
+  %"$adtgep_155" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_154", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_155"
+  %"$adtgep_156" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_154", i32 0, i32 1
+  store %Int32 %1, %Int32* %"$adtgep_156"
+  %"$adtgep_157" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_154", i32 0, i32 2
+  store %TName_List_Int32* %"$a1_153", %TName_List_Int32** %"$adtgep_157"
+  %"$adtptr_158" = bitcast %CName_Cons_Int32* %"$adtval_154" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_158", %TName_List_Int32** %"$retval_24"
+  %"$$retval_24_159" = load %TName_List_Int32*, %TName_List_Int32** %"$retval_24"
+  ret %TName_List_Int32* %"$$retval_24_159"
+}
+
+define internal { %TName_List_Int32* (i8*, %Int32)*, i8* } @"$fundef_21"(%"$$fundef_21_env_93"* %0) {
+entry:
+  %"$retval_22" = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } { %TName_List_Int32* (i8*, %Int32)* bitcast (%TName_List_Int32* (%"$$fundef_23_env_92"*, %Int32)* @"$fundef_23" to %TName_List_Int32* (i8*, %Int32)*), i8* null }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_22"
+  %"$$retval_22_143" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_22"
+  ret { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$$retval_22_143"
+}
+
+define internal %TName_List_Int64* @"$fundef_19"(%"$$fundef_19_env_94"* %0, %Int64 %1) {
+entry:
+  %"$retval_20" = alloca %TName_List_Int64*
+  %an = alloca %TName_List_Int64*
+  %"$adtval_130_load" = load i8*, i8** @_execptr
+  %"$adtval_130_salloc" = call i8* @_salloc(i8* %"$adtval_130_load", i64 1)
+  %"$adtval_130" = bitcast i8* %"$adtval_130_salloc" to %CName_Nil_Int64*
+  %"$adtgep_131" = getelementptr inbounds %CName_Nil_Int64, %CName_Nil_Int64* %"$adtval_130", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_131"
+  %"$adtptr_132" = bitcast %CName_Nil_Int64* %"$adtval_130" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_132", %TName_List_Int64** %an
+  %"$an_133" = load %TName_List_Int64*, %TName_List_Int64** %an
+  %"$adtval_134_load" = load i8*, i8** @_execptr
+  %"$adtval_134_salloc" = call i8* @_salloc(i8* %"$adtval_134_load", i64 17)
+  %"$adtval_134" = bitcast i8* %"$adtval_134_salloc" to %CName_Cons_Int64*
+  %"$adtgep_135" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_134", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_135"
+  %"$adtgep_136" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_134", i32 0, i32 1
+  store %Int64 %1, %Int64* %"$adtgep_136"
+  %"$adtgep_137" = getelementptr inbounds %CName_Cons_Int64, %CName_Cons_Int64* %"$adtval_134", i32 0, i32 2
+  store %TName_List_Int64* %"$an_133", %TName_List_Int64** %"$adtgep_137"
+  %"$adtptr_138" = bitcast %CName_Cons_Int64* %"$adtval_134" to %TName_List_Int64*
+  store %TName_List_Int64* %"$adtptr_138", %TName_List_Int64** %"$retval_20"
+  %"$$retval_20_139" = load %TName_List_Int64*, %TName_List_Int64** %"$retval_20"
+  ret %TName_List_Int64* %"$$retval_20_139"
+}
+
+define internal { %TName_List_Int64* (i8*, %Int64)*, i8* } @"$fundef_17"(%"$$fundef_17_env_95"* %0) {
+entry:
+  %"$retval_18" = alloca { %TName_List_Int64* (i8*, %Int64)*, i8* }
+  store { %TName_List_Int64* (i8*, %Int64)*, i8* } { %TName_List_Int64* (i8*, %Int64)* bitcast (%TName_List_Int64* (%"$$fundef_19_env_94"*, %Int64)* @"$fundef_19" to %TName_List_Int64* (i8*, %Int64)*), i8* null }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_18"
+  %"$$retval_18_129" = load { %TName_List_Int64* (i8*, %Int64)*, i8* }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %"$retval_18"
+  ret { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$$retval_18_129"
+}
+
+define internal %TName_List_Int32* @"$fundef_15"(%"$$fundef_15_env_96"* %0, %Int32 %1) {
+entry:
+  %"$retval_16" = alloca %TName_List_Int32*
+  %an = alloca %TName_List_Int32*
+  %"$adtval_116_load" = load i8*, i8** @_execptr
+  %"$adtval_116_salloc" = call i8* @_salloc(i8* %"$adtval_116_load", i64 1)
+  %"$adtval_116" = bitcast i8* %"$adtval_116_salloc" to %CName_Nil_Int32*
+  %"$adtgep_117" = getelementptr inbounds %CName_Nil_Int32, %CName_Nil_Int32* %"$adtval_116", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_117"
+  %"$adtptr_118" = bitcast %CName_Nil_Int32* %"$adtval_116" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_118", %TName_List_Int32** %an
+  %"$an_119" = load %TName_List_Int32*, %TName_List_Int32** %an
+  %"$adtval_120_load" = load i8*, i8** @_execptr
+  %"$adtval_120_salloc" = call i8* @_salloc(i8* %"$adtval_120_load", i64 13)
+  %"$adtval_120" = bitcast i8* %"$adtval_120_salloc" to %CName_Cons_Int32*
+  %"$adtgep_121" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_120", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_121"
+  %"$adtgep_122" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_120", i32 0, i32 1
+  store %Int32 %1, %Int32* %"$adtgep_122"
+  %"$adtgep_123" = getelementptr inbounds %CName_Cons_Int32, %CName_Cons_Int32* %"$adtval_120", i32 0, i32 2
+  store %TName_List_Int32* %"$an_119", %TName_List_Int32** %"$adtgep_123"
+  %"$adtptr_124" = bitcast %CName_Cons_Int32* %"$adtval_120" to %TName_List_Int32*
+  store %TName_List_Int32* %"$adtptr_124", %TName_List_Int32** %"$retval_16"
+  %"$$retval_16_125" = load %TName_List_Int32*, %TName_List_Int32** %"$retval_16"
+  ret %TName_List_Int32* %"$$retval_16_125"
+}
+
+define internal { %TName_List_Int32* (i8*, %Int32)*, i8* } @"$fundef_13"(%"$$fundef_13_env_97"* %0) {
+entry:
+  %"$retval_14" = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } { %TName_List_Int32* (i8*, %Int32)* bitcast (%TName_List_Int32* (%"$$fundef_15_env_96"*, %Int32)* @"$fundef_15" to %TName_List_Int32* (i8*, %Int32)*), i8* null }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_14"
+  %"$$retval_14_115" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_14"
+  ret { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$$retval_14_115"
+}
+
+define internal %Int32 @"$fundef_11"(%"$$fundef_11_env_98"* %0, %TName_List_Int64* %1) {
+entry:
+  %"$retval_12" = alloca %Int32
+  store %Int32 zeroinitializer, %Int32* %"$retval_12"
+  %"$$retval_12_111" = load %Int32, %Int32* %"$retval_12"
+  ret %Int32 %"$$retval_12_111"
+}
+
+define internal { %Int32 (i8*, %TName_List_Int64*)*, i8* } @"$fundef_9"(%"$$fundef_9_env_99"* %0) {
+entry:
+  %"$retval_10" = alloca { %Int32 (i8*, %TName_List_Int64*)*, i8* }
+  store { %Int32 (i8*, %TName_List_Int64*)*, i8* } { %Int32 (i8*, %TName_List_Int64*)* bitcast (%Int32 (%"$$fundef_11_env_98"*, %TName_List_Int64*)* @"$fundef_11" to %Int32 (i8*, %TName_List_Int64*)*), i8* null }, { %Int32 (i8*, %TName_List_Int64*)*, i8* }* %"$retval_10"
+  %"$$retval_10_110" = load { %Int32 (i8*, %TName_List_Int64*)*, i8* }, { %Int32 (i8*, %TName_List_Int64*)*, i8* }* %"$retval_10"
+  ret { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$$retval_10_110"
+}
+
+define internal %Int32 @"$fundef_7"(%"$$fundef_7_env_100"* %0, %TName_List_Int32* %1) {
+entry:
+  %"$retval_8" = alloca %Int32
+  store %Int32 zeroinitializer, %Int32* %"$retval_8"
+  %"$$retval_8_106" = load %Int32, %Int32* %"$retval_8"
+  ret %Int32 %"$$retval_8_106"
+}
+
+define internal { %Int32 (i8*, %TName_List_Int32*)*, i8* } @"$fundef_5"(%"$$fundef_5_env_101"* %0) {
+entry:
+  %"$retval_6" = alloca { %Int32 (i8*, %TName_List_Int32*)*, i8* }
+  store { %Int32 (i8*, %TName_List_Int32*)*, i8* } { %Int32 (i8*, %TName_List_Int32*)* bitcast (%Int32 (%"$$fundef_7_env_100"*, %TName_List_Int32*)* @"$fundef_7" to %Int32 (i8*, %TName_List_Int32*)*), i8* null }, { %Int32 (i8*, %TName_List_Int32*)*, i8* }* %"$retval_6"
+  %"$$retval_6_105" = load { %Int32 (i8*, %TName_List_Int32*)*, i8* }, { %Int32 (i8*, %TName_List_Int32*)*, i8* }* %"$retval_6"
+  ret { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$$retval_6_105"
+}
+
+declare i8* @_salloc(i8*, i64)
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal %Int32 @"$scilla_expr_180"(i8* %0) {
+entry:
+  %"$expr_4" = alloca %Int32
+  %list_length_dummy = alloca { i8*, i8* }*
+  store { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* } { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)* bitcast ({ %Int32 (i8*, %TName_List_Int32*)*, i8* } (%"$$fundef_5_env_101"*)* @"$fundef_5" to { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*), i8* null }, { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_187" to { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }*)
+  store { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* } { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)* bitcast ({ %Int32 (i8*, %TName_List_Int64*)*, i8* } (%"$$fundef_9_env_99"*)* @"$fundef_9" to { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*), i8* null }, { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_187", i32 0, i32 1) to { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_187", i32 0, i32 0), { i8*, i8* }** %list_length_dummy
+  %t1 = alloca { i8*, i8* }*
+  store { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)* bitcast ({ %TName_List_Int32* (i8*, %Int32)*, i8* } (%"$$fundef_13_env_97"*)* @"$fundef_13" to { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*), i8* null }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_194" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }*)
+  store { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* } { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)* bitcast ({ %TName_List_Int64* (i8*, %Int64)*, i8* } (%"$$fundef_17_env_95"*)* @"$fundef_17" to { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*), i8* null }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_194", i32 0, i32 1) to { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_194", i32 0, i32 0), { i8*, i8* }** %t1
+  %t2 = alloca { i8*, i8* }*
+  store { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)* bitcast ({ %TName_List_Int32* (i8*, %Int32)*, i8* } (%"$$fundef_21_env_93"*)* @"$fundef_21" to { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*), i8* null }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_201" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }*)
+  store { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* } { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)* bitcast ({ %TName_List_Int64* (i8*, %Int64)*, i8* } (%"$$fundef_25_env_91"*)* @"$fundef_25" to { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*), i8* null }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_201", i32 0, i32 1) to { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_201", i32 0, i32 0), { i8*, i8* }** %t2
+  %some_bool = alloca %Bool*
+  %"$adtval_202_load" = load i8*, i8** @_execptr
+  %"$adtval_202_salloc" = call i8* @_salloc(i8* %"$adtval_202_load", i64 1)
+  %"$adtval_202" = bitcast i8* %"$adtval_202_salloc" to %True*
+  %"$adtgep_203" = getelementptr inbounds %True, %True* %"$adtval_202", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_203"
+  %"$adtptr_204" = bitcast %True* %"$adtval_202" to %Bool*
+  store %Bool* %"$adtptr_204", %Bool** %some_bool
+  %f = alloca { i8*, i8* }*
+  %"$some_bool_206" = load %Bool*, %Bool** %some_bool
+  %"$some_bool_tag_207" = getelementptr inbounds %Bool, %Bool* %"$some_bool_206", i32 0, i32 0
+  %"$some_bool_tag_208" = load i8, i8* %"$some_bool_tag_207"
+  switch i8 %"$some_bool_tag_208", label %"$empty_default_209" [
+    i8 0, label %"$True_210"
+    i8 1, label %"$False_213"
+  ]
+
+"$True_210":                                      ; preds = %entry
+  %"$some_bool_211" = bitcast %Bool* %"$some_bool_206" to %True*
+  %"$t1_212" = load { i8*, i8* }*, { i8*, i8* }** %t1
+  store { i8*, i8* }* %"$t1_212", { i8*, i8* }** %f
+  br label %"$matchsucc_205"
+
+"$False_213":                                     ; preds = %entry
+  %"$some_bool_214" = bitcast %Bool* %"$some_bool_206" to %False*
+  %"$t2_215" = load { i8*, i8* }*, { i8*, i8* }** %t2
+  store { i8*, i8* }* %"$t2_215", { i8*, i8* }** %f
+  br label %"$matchsucc_205"
+
+"$empty_default_209":                             ; preds = %entry
+  br label %"$matchsucc_205"
+
+"$matchsucc_205":                                 ; preds = %"$False_213", %"$True_210", %"$empty_default_209"
+  %some_bool2 = alloca %Bool*
+  %"$adtval_216_load" = load i8*, i8** @_execptr
+  %"$adtval_216_salloc" = call i8* @_salloc(i8* %"$adtval_216_load", i64 1)
+  %"$adtval_216" = bitcast i8* %"$adtval_216_salloc" to %False*
+  %"$adtgep_217" = getelementptr inbounds %False, %False* %"$adtval_216", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_217"
+  %"$adtptr_218" = bitcast %False* %"$adtval_216" to %Bool*
+  store %Bool* %"$adtptr_218", %Bool** %some_bool2
+  %"$some_bool2_220" = load %Bool*, %Bool** %some_bool2
+  %"$some_bool2_tag_221" = getelementptr inbounds %Bool, %Bool* %"$some_bool2_220", i32 0, i32 0
+  %"$some_bool2_tag_222" = load i8, i8* %"$some_bool2_tag_221"
+  switch i8 %"$some_bool2_tag_222", label %"$empty_default_223" [
+    i8 0, label %"$True_224"
+    i8 1, label %"$False_252"
+  ]
+
+"$True_224":                                      ; preds = %"$matchsucc_205"
+  %"$some_bool2_225" = bitcast %Bool* %"$some_bool2_220" to %True*
+  %f1 = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  %"$f_226" = load { i8*, i8* }*, { i8*, i8* }** %f
+  %"$f_227" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$f_226", i32 0
+  %"$f_228" = bitcast { i8*, i8* }* %"$f_227" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }*
+  %"$f_229" = load { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }* %"$f_228"
+  %"$f_fptr_230" = extractvalue { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } %"$f_229", 0
+  %"$f_envptr_231" = extractvalue { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } %"$f_229", 1
+  %"$f_call_232" = call { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f_fptr_230"(i8* %"$f_envptr_231")
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f_call_232", { %TName_List_Int32* (i8*, %Int32)*, i8* }* %f1
+  %len = alloca { %Int32 (i8*, %TName_List_Int32*)*, i8* }
+  %"$list_length_dummy_233" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  %"$list_length_dummy_234" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$list_length_dummy_233", i32 0
+  %"$list_length_dummy_235" = bitcast { i8*, i8* }* %"$list_length_dummy_234" to { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }*
+  %"$list_length_dummy_236" = load { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }, { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* }* %"$list_length_dummy_235"
+  %"$list_length_dummy_fptr_237" = extractvalue { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_236", 0
+  %"$list_length_dummy_envptr_238" = extractvalue { { %Int32 (i8*, %TName_List_Int32*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_236", 1
+  %"$list_length_dummy_call_239" = call { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$list_length_dummy_fptr_237"(i8* %"$list_length_dummy_envptr_238")
+  store { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$list_length_dummy_call_239", { %Int32 (i8*, %TName_List_Int32*)*, i8* }* %len
+  %one = alloca %Int32
+  store %Int32 { i32 1 }, %Int32* %one
+  %f1l = alloca %TName_List_Int32*
+  %"$f1_0" = alloca %TName_List_Int32*
+  %"$f1_240" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %f1
+  %"$f1_fptr_241" = extractvalue { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f1_240", 0
+  %"$f1_envptr_242" = extractvalue { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f1_240", 1
+  %"$one_243" = load %Int32, %Int32* %one
+  %"$f1_call_244" = call %TName_List_Int32* %"$f1_fptr_241"(i8* %"$f1_envptr_242", %Int32 %"$one_243")
+  store %TName_List_Int32* %"$f1_call_244", %TName_List_Int32** %"$f1_0"
+  %"$$f1_0_245" = load %TName_List_Int32*, %TName_List_Int32** %"$f1_0"
+  store %TName_List_Int32* %"$$f1_0_245", %TName_List_Int32** %f1l
+  %"$len_1" = alloca %Int32
+  %"$len_246" = load { %Int32 (i8*, %TName_List_Int32*)*, i8* }, { %Int32 (i8*, %TName_List_Int32*)*, i8* }* %len
+  %"$len_fptr_247" = extractvalue { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$len_246", 0
+  %"$len_envptr_248" = extractvalue { %Int32 (i8*, %TName_List_Int32*)*, i8* } %"$len_246", 1
+  %"$f1l_249" = load %TName_List_Int32*, %TName_List_Int32** %f1l
+  %"$len_call_250" = call %Int32 %"$len_fptr_247"(i8* %"$len_envptr_248", %TName_List_Int32* %"$f1l_249")
+  store %Int32 %"$len_call_250", %Int32* %"$len_1"
+  %"$$len_1_251" = load %Int32, %Int32* %"$len_1"
+  store %Int32 %"$$len_1_251", %Int32* %"$expr_4"
+  br label %"$matchsucc_219"
+
+"$False_252":                                     ; preds = %"$matchsucc_205"
+  %"$some_bool2_253" = bitcast %Bool* %"$some_bool2_220" to %False*
+  %f2 = alloca { %TName_List_Int64* (i8*, %Int64)*, i8* }
+  %"$f_254" = load { i8*, i8* }*, { i8*, i8* }** %f
+  %"$f_255" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$f_254", i32 1
+  %"$f_256" = bitcast { i8*, i8* }* %"$f_255" to { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }*
+  %"$f_257" = load { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }, { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* }* %"$f_256"
+  %"$f_fptr_258" = extractvalue { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* } %"$f_257", 0
+  %"$f_envptr_259" = extractvalue { { %TName_List_Int64* (i8*, %Int64)*, i8* } (i8*)*, i8* } %"$f_257", 1
+  %"$f_call_260" = call { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f_fptr_258"(i8* %"$f_envptr_259")
+  store { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f_call_260", { %TName_List_Int64* (i8*, %Int64)*, i8* }* %f2
+  %len1 = alloca { %Int32 (i8*, %TName_List_Int64*)*, i8* }
+  %"$list_length_dummy_261" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  %"$list_length_dummy_262" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$list_length_dummy_261", i32 1
+  %"$list_length_dummy_263" = bitcast { i8*, i8* }* %"$list_length_dummy_262" to { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }*
+  %"$list_length_dummy_264" = load { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }, { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* }* %"$list_length_dummy_263"
+  %"$list_length_dummy_fptr_265" = extractvalue { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_264", 0
+  %"$list_length_dummy_envptr_266" = extractvalue { { %Int32 (i8*, %TName_List_Int64*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_264", 1
+  %"$list_length_dummy_call_267" = call { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$list_length_dummy_fptr_265"(i8* %"$list_length_dummy_envptr_266")
+  store { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$list_length_dummy_call_267", { %Int32 (i8*, %TName_List_Int64*)*, i8* }* %len1
+  %one2 = alloca %Int64
+  store %Int64 { i64 1 }, %Int64* %one2
+  %f2l = alloca %TName_List_Int64*
+  %"$f2_2" = alloca %TName_List_Int64*
+  %"$f2_268" = load { %TName_List_Int64* (i8*, %Int64)*, i8* }, { %TName_List_Int64* (i8*, %Int64)*, i8* }* %f2
+  %"$f2_fptr_269" = extractvalue { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f2_268", 0
+  %"$f2_envptr_270" = extractvalue { %TName_List_Int64* (i8*, %Int64)*, i8* } %"$f2_268", 1
+  %"$one_271" = load %Int64, %Int64* %one2
+  %"$f2_call_272" = call %TName_List_Int64* %"$f2_fptr_269"(i8* %"$f2_envptr_270", %Int64 %"$one_271")
+  store %TName_List_Int64* %"$f2_call_272", %TName_List_Int64** %"$f2_2"
+  %"$$f2_2_273" = load %TName_List_Int64*, %TName_List_Int64** %"$f2_2"
+  store %TName_List_Int64* %"$$f2_2_273", %TName_List_Int64** %f2l
+  %"$len_3" = alloca %Int32
+  %"$len_274" = load { %Int32 (i8*, %TName_List_Int64*)*, i8* }, { %Int32 (i8*, %TName_List_Int64*)*, i8* }* %len1
+  %"$len_fptr_275" = extractvalue { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$len_274", 0
+  %"$len_envptr_276" = extractvalue { %Int32 (i8*, %TName_List_Int64*)*, i8* } %"$len_274", 1
+  %"$f2l_277" = load %TName_List_Int64*, %TName_List_Int64** %f2l
+  %"$len_call_278" = call %Int32 %"$len_fptr_275"(i8* %"$len_envptr_276", %TName_List_Int64* %"$f2l_277")
+  store %Int32 %"$len_call_278", %Int32* %"$len_3"
+  %"$$len_3_279" = load %Int32, %Int32* %"$len_3"
+  store %Int32 %"$$len_3_279", %Int32* %"$expr_4"
+  br label %"$matchsucc_219"
+
+"$empty_default_223":                             ; preds = %"$matchsucc_205"
+  br label %"$matchsucc_219"
+
+"$matchsucc_219":                                 ; preds = %"$False_252", %"$True_224", %"$empty_default_223"
+  %"$$expr_4_280" = load %Int32, %Int32* %"$expr_4"
+  ret %Int32 %"$$expr_4_280"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$exprval_281" = call %Int32 @"$scilla_expr_180"(i8* null)
+  %"$pval_282" = alloca %Int32
+  %"$memvoidcast_283" = bitcast %Int32* %"$pval_282" to i8*
+  store %Int32 %"$exprval_281", %Int32* %"$pval_282"
+  call void @_print_scilla_val(%_TyDescrTy_Typ* @"$TyDescr_Int32_31", i8* %"$memvoidcast_283")
+  ret void
+}

--- a/tests/codegen/expr/gold/nonprenex.scilexp.gold
+++ b/tests/codegen/expr/gold/nonprenex.scilexp.gold
@@ -1,6 +1,450 @@
-Specializing [codegen/expr/nonprenex.scilexp:2:8] 'A with String
-Specializing [codegen/expr/nonprenex.scilexp:2:8] 'A with ByStr20
-Specializing [codegen/expr/nonprenex.scilexp:8:8] 'A with String
-Specializing [codegen/expr/nonprenex.scilexp:8:8] 'A with ByStr20
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_29" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$TyDescrTy_ADTTyp_53" = type { %TyDescrString, i32, i32, i32, %"$TyDescrTy_ADTTyp_Specl_52"** }
+%TyDescrString = type { i8*, i32 }
+%"$TyDescrTy_ADTTyp_Specl_52" = type { %_TyDescrTy_Typ**, %"$TyDescrTy_ADTTyp_Constr_54"**, %"$TyDescrTy_ADTTyp_53"* }
+%"$TyDescrTy_ADTTyp_Constr_54" = type { %TyDescrString, i32, %_TyDescrTy_Typ** }
+%"$$fundef_27_env_92" = type { %Bool*, { i8*, i8* }* }
+%Bool = type { i8, %True*, %False* }
+%True = type <{ i8 }>
+%False = type <{ i8 }>
+%"$$fundef_25_env_93" = type { %Bool* }
+%"$$fundef_23_env_94" = type {}
+%Uint32 = type { i32 }
+%"$$fundef_21_env_95" = type { { i8*, i8* }* }
+%TName_List_ByStr20 = type { i8, %CName_Cons_ByStr20*, %CName_Nil_ByStr20* }
+%CName_Cons_ByStr20 = type <{ i8, [20 x i8], %TName_List_ByStr20* }>
+%CName_Nil_ByStr20 = type <{ i8 }>
+%"$$fundef_19_env_96" = type { { i8*, i8* }* }
+%"$$fundef_17_env_97" = type { { i8*, i8* }* }
+%TName_List_String = type { i8, %CName_Cons_String*, %CName_Nil_String* }
+%CName_Cons_String = type <{ i8, %String, %TName_List_String* }>
+%String = type { i8*, i32 }
+%CName_Nil_String = type <{ i8 }>
+%"$$fundef_15_env_98" = type { { i8*, i8* }* }
+%"$$fundef_13_env_99" = type {}
+%"$$fundef_11_env_100" = type {}
+%"$$fundef_9_env_101" = type {}
+%"$$fundef_7_env_102" = type {}
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_30" = global %"$TyDescrTy_PrimTyp_29" zeroinitializer
+@"$TyDescr_Int32_31" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int32_Prim_30" to i8*) }
+@"$TyDescr_Uint32_Prim_32" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 0 }
+@"$TyDescr_Uint32_33" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint32_Prim_32" to i8*) }
+@"$TyDescr_Int64_Prim_34" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 1 }
+@"$TyDescr_Int64_35" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int64_Prim_34" to i8*) }
+@"$TyDescr_Uint64_Prim_36" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 1 }
+@"$TyDescr_Uint64_37" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint64_Prim_36" to i8*) }
+@"$TyDescr_Int128_Prim_38" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 2 }
+@"$TyDescr_Int128_39" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int128_Prim_38" to i8*) }
+@"$TyDescr_Uint128_Prim_40" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 2 }
+@"$TyDescr_Uint128_41" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint128_Prim_40" to i8*) }
+@"$TyDescr_Int256_Prim_42" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 3 }
+@"$TyDescr_Int256_43" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int256_Prim_42" to i8*) }
+@"$TyDescr_Uint256_Prim_44" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 3 }
+@"$TyDescr_Uint256_45" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint256_Prim_44" to i8*) }
+@"$TyDescr_String_Prim_46" = global %"$TyDescrTy_PrimTyp_29" { i32 2, i32 0 }
+@"$TyDescr_String_47" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_String_Prim_46" to i8*) }
+@"$TyDescr_Bystr_Prim_48" = global %"$TyDescrTy_PrimTyp_29" { i32 7, i32 0 }
+@"$TyDescr_Bystr_49" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Bystr_Prim_48" to i8*) }
+@"$TyDescr_Bystr20_Prim_50" = global %"$TyDescrTy_PrimTyp_29" { i32 8, i32 20 }
+@"$TyDescr_Bystr20_51" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Bystr20_Prim_50" to i8*) }
+@"$TyDescr_ADT_Bool_55" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_Bool_ADTTyp_Specl_68" to i8*) }
+@"$TyDescr_ADT_List_ByStr20_56" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_List_ByStr20_ADTTyp_Specl_80" to i8*) }
+@"$TyDescr_ADT_List_String_57" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_List_String_ADTTyp_Specl_89" to i8*) }
+@"$TyDescr_Bool_ADTTyp_59" = unnamed_addr constant %"$TyDescrTy_ADTTyp_53" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Bool_70", i32 0, i32 0), i32 4 }, i32 0, i32 2, i32 1, %"$TyDescrTy_ADTTyp_Specl_52"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Specl_52"*], [1 x %"$TyDescrTy_ADTTyp_Specl_52"*]* @"$TyDescr_Bool_ADTTyp_m_specls_69", i32 0, i32 0) }
+@"$TyDescr_Bool_True_Constr_m_args_60" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_True_61" = unnamed_addr constant [4 x i8] c"True"
+@"$TyDescr_Bool_True_ADTTyp_Constr_62" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_True_61", i32 0, i32 0), i32 4 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_True_Constr_m_args_60", i32 0, i32 0) }
+@"$TyDescr_Bool_False_Constr_m_args_63" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_False_64" = unnamed_addr constant [5 x i8] c"False"
+@"$TyDescr_Bool_False_ADTTyp_Constr_65" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"$TyDescr_ADT_False_64", i32 0, i32 0), i32 5 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_False_Constr_m_args_63", i32 0, i32 0) }
+@"$TyDescr_Bool_ADTTyp_Specl_m_constrs_66" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_54"*] [%"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_Bool_True_ADTTyp_Constr_62", %"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_Bool_False_ADTTyp_Constr_65"]
+@"$TyDescr_Bool_ADTTyp_Specl_m_TArgs_67" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_Bool_ADTTyp_Specl_68" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_52" { %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_Bool_ADTTyp_Specl_m_TArgs_67", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_54"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_54"*], [2 x %"$TyDescrTy_ADTTyp_Constr_54"*]* @"$TyDescr_Bool_ADTTyp_Specl_m_constrs_66", i32 0, i32 0), %"$TyDescrTy_ADTTyp_53"* @"$TyDescr_Bool_ADTTyp_59" }
+@"$TyDescr_Bool_ADTTyp_m_specls_69" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Specl_52"*] [%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_Bool_ADTTyp_Specl_68"]
+@"$TyDescr_ADT_Bool_70" = unnamed_addr constant [4 x i8] c"Bool"
+@"$TyDescr_List_ADTTyp_71" = unnamed_addr constant %"$TyDescrTy_ADTTyp_53" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_List_91", i32 0, i32 0), i32 4 }, i32 1, i32 2, i32 2, %"$TyDescrTy_ADTTyp_Specl_52"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Specl_52"*], [2 x %"$TyDescrTy_ADTTyp_Specl_52"*]* @"$TyDescr_List_ADTTyp_m_specls_90", i32 0, i32 0) }
+@"$TyDescr_List_Cons_ByStr20_Constr_m_args_72" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Bystr20_51", %_TyDescrTy_Typ* @"$TyDescr_ADT_List_ByStr20_56"]
+@"$TyDescr_ADT_Cons_73" = unnamed_addr constant [4 x i8] c"Cons"
+@"$TyDescr_List_Cons_ByStr20_ADTTyp_Constr_74" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Cons_73", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Cons_ByStr20_Constr_m_args_72", i32 0, i32 0) }
+@"$TyDescr_List_Nil_ByStr20_Constr_m_args_75" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_Nil_76" = unnamed_addr constant [3 x i8] c"Nil"
+@"$TyDescr_List_Nil_ByStr20_ADTTyp_Constr_77" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"$TyDescr_ADT_Nil_76", i32 0, i32 0), i32 3 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Nil_ByStr20_Constr_m_args_75", i32 0, i32 0) }
+@"$TyDescr_List_ByStr20_ADTTyp_Specl_m_constrs_78" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_54"*] [%"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_List_Cons_ByStr20_ADTTyp_Constr_74", %"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_List_Nil_ByStr20_ADTTyp_Constr_77"]
+@"$TyDescr_List_ByStr20_ADTTyp_Specl_m_TArgs_79" = unnamed_addr constant [1 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Bystr20_51"]
+@"$TyDescr_List_ByStr20_ADTTyp_Specl_80" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_52" { %_TyDescrTy_Typ** getelementptr inbounds ([1 x %_TyDescrTy_Typ*], [1 x %_TyDescrTy_Typ*]* @"$TyDescr_List_ByStr20_ADTTyp_Specl_m_TArgs_79", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_54"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_54"*], [2 x %"$TyDescrTy_ADTTyp_Constr_54"*]* @"$TyDescr_List_ByStr20_ADTTyp_Specl_m_constrs_78", i32 0, i32 0), %"$TyDescrTy_ADTTyp_53"* @"$TyDescr_List_ADTTyp_71" }
+@"$TyDescr_List_Cons_String_Constr_m_args_81" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_String_47", %_TyDescrTy_Typ* @"$TyDescr_ADT_List_String_57"]
+@"$TyDescr_ADT_Cons_82" = unnamed_addr constant [4 x i8] c"Cons"
+@"$TyDescr_List_Cons_String_ADTTyp_Constr_83" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Cons_82", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Cons_String_Constr_m_args_81", i32 0, i32 0) }
+@"$TyDescr_List_Nil_String_Constr_m_args_84" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_Nil_85" = unnamed_addr constant [3 x i8] c"Nil"
+@"$TyDescr_List_Nil_String_ADTTyp_Constr_86" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"$TyDescr_ADT_Nil_85", i32 0, i32 0), i32 3 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Nil_String_Constr_m_args_84", i32 0, i32 0) }
+@"$TyDescr_List_String_ADTTyp_Specl_m_constrs_87" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_54"*] [%"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_List_Cons_String_ADTTyp_Constr_83", %"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_List_Nil_String_ADTTyp_Constr_86"]
+@"$TyDescr_List_String_ADTTyp_Specl_m_TArgs_88" = unnamed_addr constant [1 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_String_47"]
+@"$TyDescr_List_String_ADTTyp_Specl_89" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_52" { %_TyDescrTy_Typ** getelementptr inbounds ([1 x %_TyDescrTy_Typ*], [1 x %_TyDescrTy_Typ*]* @"$TyDescr_List_String_ADTTyp_Specl_m_TArgs_88", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_54"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_54"*], [2 x %"$TyDescrTy_ADTTyp_Constr_54"*]* @"$TyDescr_List_String_ADTTyp_Specl_m_constrs_87", i32 0, i32 0), %"$TyDescrTy_ADTTyp_53"* @"$TyDescr_List_ADTTyp_71" }
+@"$TyDescr_List_ADTTyp_m_specls_90" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Specl_52"*] [%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_List_ByStr20_ADTTyp_Specl_80", %"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_List_String_ADTTyp_Specl_89"]
+@"$TyDescr_ADT_List_91" = unnamed_addr constant [4 x i8] c"List"
+@"$dyndisp_205" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_215" = global [2 x { i8*, i8* }] zeroinitializer
+
+define internal { i8*, i8* }* @"$fundef_27"(%"$$fundef_27_env_92"* %0, { i8*, i8* }* %1) {
+entry:
+  %"$$fundef_27_env_b_183" = getelementptr inbounds %"$$fundef_27_env_92", %"$$fundef_27_env_92"* %0, i32 0, i32 0
+  %"$b_envload_184" = load %Bool*, %Bool** %"$$fundef_27_env_b_183"
+  %b = alloca %Bool*
+  store %Bool* %"$b_envload_184", %Bool** %b
+  %"$$fundef_27_env_f_185" = getelementptr inbounds %"$$fundef_27_env_92", %"$$fundef_27_env_92"* %0, i32 0, i32 1
+  %"$f_envload_186" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_27_env_f_185"
+  %f = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$f_envload_186", { i8*, i8* }** %f
+  %"$retval_28" = alloca { i8*, i8* }*
+  %"$b_188" = load %Bool*, %Bool** %b
+  %"$b_tag_189" = getelementptr inbounds %Bool, %Bool* %"$b_188", i32 0, i32 0
+  %"$b_tag_190" = load i8, i8* %"$b_tag_189"
+  switch i8 %"$b_tag_190", label %"$empty_default_191" [
+    i8 0, label %"$True_192"
+    i8 1, label %"$False_194"
+  ]
+
+"$True_192":                                      ; preds = %entry
+  %"$b_193" = bitcast %Bool* %"$b_188" to %True*
+  store { i8*, i8* }* %1, { i8*, i8* }** %"$retval_28"
+  br label %"$matchsucc_187"
+
+"$False_194":                                     ; preds = %entry
+  %"$b_195" = bitcast %Bool* %"$b_188" to %False*
+  %"$f_196" = load { i8*, i8* }*, { i8*, i8* }** %f
+  store { i8*, i8* }* %"$f_196", { i8*, i8* }** %"$retval_28"
+  br label %"$matchsucc_187"
+
+"$empty_default_191":                             ; preds = %entry
+  br label %"$matchsucc_187"
+
+"$matchsucc_187":                                 ; preds = %"$False_194", %"$True_192", %"$empty_default_191"
+  %"$$retval_28_197" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_28"
+  ret { i8*, i8* }* %"$$retval_28_197"
+}
+
+define internal { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } @"$fundef_25"(%"$$fundef_25_env_93"* %0, { i8*, i8* }* %1) {
+entry:
+  %"$$fundef_25_env_b_173" = getelementptr inbounds %"$$fundef_25_env_93", %"$$fundef_25_env_93"* %0, i32 0, i32 0
+  %"$b_envload_174" = load %Bool*, %Bool** %"$$fundef_25_env_b_173"
+  %b = alloca %Bool*
+  store %Bool* %"$b_envload_174", %Bool** %b
+  %"$retval_26" = alloca { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* }
+  %"$$fundef_27_envp_175_load" = load i8*, i8** @_execptr
+  %"$$fundef_27_envp_175_salloc" = call i8* @_salloc(i8* %"$$fundef_27_envp_175_load", i64 16)
+  %"$$fundef_27_envp_175" = bitcast i8* %"$$fundef_27_envp_175_salloc" to %"$$fundef_27_env_92"*
+  %"$$fundef_27_env_voidp_177" = bitcast %"$$fundef_27_env_92"* %"$$fundef_27_envp_175" to i8*
+  %"$$fundef_27_cloval_178" = insertvalue { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } { { i8*, i8* }* (i8*, { i8*, i8* }*)* bitcast ({ i8*, i8* }* (%"$$fundef_27_env_92"*, { i8*, i8* }*)* @"$fundef_27" to { i8*, i8* }* (i8*, { i8*, i8* }*)*), i8* undef }, i8* %"$$fundef_27_env_voidp_177", 1
+  %"$$fundef_27_env_b_179" = getelementptr inbounds %"$$fundef_27_env_92", %"$$fundef_27_env_92"* %"$$fundef_27_envp_175", i32 0, i32 0
+  %"$b_180" = load %Bool*, %Bool** %b
+  store %Bool* %"$b_180", %Bool** %"$$fundef_27_env_b_179"
+  %"$$fundef_27_env_f_181" = getelementptr inbounds %"$$fundef_27_env_92", %"$$fundef_27_env_92"* %"$$fundef_27_envp_175", i32 0, i32 1
+  store { i8*, i8* }* %1, { i8*, i8* }** %"$$fundef_27_env_f_181"
+  store { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } %"$$fundef_27_cloval_178", { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* }* %"$retval_26"
+  %"$$retval_26_182" = load { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* }, { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* }* %"$retval_26"
+  ret { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } %"$$retval_26_182"
+}
+
+define internal { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } @"$fundef_23"(%"$$fundef_23_env_94"* %0, %Bool* %1) {
+entry:
+  %"$retval_24" = alloca { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  %"$$fundef_25_envp_167_load" = load i8*, i8** @_execptr
+  %"$$fundef_25_envp_167_salloc" = call i8* @_salloc(i8* %"$$fundef_25_envp_167_load", i64 8)
+  %"$$fundef_25_envp_167" = bitcast i8* %"$$fundef_25_envp_167_salloc" to %"$$fundef_25_env_93"*
+  %"$$fundef_25_env_voidp_169" = bitcast %"$$fundef_25_env_93"* %"$$fundef_25_envp_167" to i8*
+  %"$$fundef_25_cloval_170" = insertvalue { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)* bitcast ({ { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (%"$$fundef_25_env_93"*, { i8*, i8* }*)* @"$fundef_25" to { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*), i8* undef }, i8* %"$$fundef_25_env_voidp_169", 1
+  %"$$fundef_25_env_b_171" = getelementptr inbounds %"$$fundef_25_env_93", %"$$fundef_25_env_93"* %"$$fundef_25_envp_167", i32 0, i32 0
+  store %Bool* %1, %Bool** %"$$fundef_25_env_b_171"
+  store { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$fundef_25_cloval_170", { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_24"
+  %"$$retval_24_172" = load { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_24"
+  ret { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$retval_24_172"
+}
+
+define internal %Uint32 @"$fundef_21"(%"$$fundef_21_env_95"* %0, %TName_List_ByStr20* %1) {
+entry:
+  %"$$fundef_21_env_list_length_dummy_149" = getelementptr inbounds %"$$fundef_21_env_95", %"$$fundef_21_env_95"* %0, i32 0, i32 0
+  %"$list_length_dummy_envload_150" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_21_env_list_length_dummy_149"
+  %list_length_dummy = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$list_length_dummy_envload_150", { i8*, i8* }** %list_length_dummy
+  %"$retval_22" = alloca %Uint32
+  %ll = alloca { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }
+  %"$list_length_dummy_151" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  %"$list_length_dummy_152" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$list_length_dummy_151", i32 1
+  %"$list_length_dummy_153" = bitcast { i8*, i8* }* %"$list_length_dummy_152" to { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }*
+  %"$list_length_dummy_154" = load { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }, { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }* %"$list_length_dummy_153"
+  %"$list_length_dummy_fptr_155" = extractvalue { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_154", 0
+  %"$list_length_dummy_envptr_156" = extractvalue { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_154", 1
+  %"$list_length_dummy_call_157" = call { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$list_length_dummy_fptr_155"(i8* %"$list_length_dummy_envptr_156")
+  store { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$list_length_dummy_call_157", { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }* %ll
+  %n = alloca %Uint32
+  %"$ll_0" = alloca %Uint32
+  %"$ll_158" = load { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }, { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }* %ll
+  %"$ll_fptr_159" = extractvalue { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$ll_158", 0
+  %"$ll_envptr_160" = extractvalue { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$ll_158", 1
+  %"$ll_call_161" = call %Uint32 %"$ll_fptr_159"(i8* %"$ll_envptr_160", %TName_List_ByStr20* %1)
+  store %Uint32 %"$ll_call_161", %Uint32* %"$ll_0"
+  %"$$ll_0_162" = load %Uint32, %Uint32* %"$ll_0"
+  store %Uint32 %"$$ll_0_162", %Uint32* %n
+  %two = alloca %Uint32
+  store %Uint32 { i32 2 }, %Uint32* %two
+  %"$n_163" = load %Uint32, %Uint32* %n
+  %"$two_164" = load %Uint32, %Uint32* %two
+  %"$add_call_165" = call %Uint32 @_add_Uint32(%Uint32 %"$n_163", %Uint32 %"$two_164")
+  store %Uint32 %"$add_call_165", %Uint32* %"$retval_22"
+  %"$$retval_22_166" = load %Uint32, %Uint32* %"$retval_22"
+  ret %Uint32 %"$$retval_22_166"
+}
+
+define internal { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } @"$fundef_19"(%"$$fundef_19_env_96"* %0) {
+entry:
+  %"$$fundef_19_env_list_length_dummy_140" = getelementptr inbounds %"$$fundef_19_env_96", %"$$fundef_19_env_96"* %0, i32 0, i32 0
+  %"$list_length_dummy_envload_141" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_19_env_list_length_dummy_140"
+  %list_length_dummy = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$list_length_dummy_envload_141", { i8*, i8* }** %list_length_dummy
+  %"$retval_20" = alloca { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }
+  %"$$fundef_21_envp_142_load" = load i8*, i8** @_execptr
+  %"$$fundef_21_envp_142_salloc" = call i8* @_salloc(i8* %"$$fundef_21_envp_142_load", i64 8)
+  %"$$fundef_21_envp_142" = bitcast i8* %"$$fundef_21_envp_142_salloc" to %"$$fundef_21_env_95"*
+  %"$$fundef_21_env_voidp_144" = bitcast %"$$fundef_21_env_95"* %"$$fundef_21_envp_142" to i8*
+  %"$$fundef_21_cloval_145" = insertvalue { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } { %Uint32 (i8*, %TName_List_ByStr20*)* bitcast (%Uint32 (%"$$fundef_21_env_95"*, %TName_List_ByStr20*)* @"$fundef_21" to %Uint32 (i8*, %TName_List_ByStr20*)*), i8* undef }, i8* %"$$fundef_21_env_voidp_144", 1
+  %"$$fundef_21_env_list_length_dummy_146" = getelementptr inbounds %"$$fundef_21_env_95", %"$$fundef_21_env_95"* %"$$fundef_21_envp_142", i32 0, i32 0
+  %"$list_length_dummy_147" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  store { i8*, i8* }* %"$list_length_dummy_147", { i8*, i8* }** %"$$fundef_21_env_list_length_dummy_146"
+  store { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$$fundef_21_cloval_145", { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }* %"$retval_20"
+  %"$$retval_20_148" = load { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }, { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }* %"$retval_20"
+  ret { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$$retval_20_148"
+}
+
+define internal %Uint32 @"$fundef_17"(%"$$fundef_17_env_97"* %0, %TName_List_String* %1) {
+entry:
+  %"$$fundef_17_env_list_length_dummy_122" = getelementptr inbounds %"$$fundef_17_env_97", %"$$fundef_17_env_97"* %0, i32 0, i32 0
+  %"$list_length_dummy_envload_123" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_17_env_list_length_dummy_122"
+  %list_length_dummy = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$list_length_dummy_envload_123", { i8*, i8* }** %list_length_dummy
+  %"$retval_18" = alloca %Uint32
+  %ll = alloca { %Uint32 (i8*, %TName_List_String*)*, i8* }
+  %"$list_length_dummy_124" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  %"$list_length_dummy_125" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$list_length_dummy_124", i32 0
+  %"$list_length_dummy_126" = bitcast { i8*, i8* }* %"$list_length_dummy_125" to { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }*
+  %"$list_length_dummy_127" = load { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }, { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }* %"$list_length_dummy_126"
+  %"$list_length_dummy_fptr_128" = extractvalue { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_127", 0
+  %"$list_length_dummy_envptr_129" = extractvalue { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* } %"$list_length_dummy_127", 1
+  %"$list_length_dummy_call_130" = call { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$list_length_dummy_fptr_128"(i8* %"$list_length_dummy_envptr_129")
+  store { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$list_length_dummy_call_130", { %Uint32 (i8*, %TName_List_String*)*, i8* }* %ll
+  %n = alloca %Uint32
+  %"$ll_0" = alloca %Uint32
+  %"$ll_131" = load { %Uint32 (i8*, %TName_List_String*)*, i8* }, { %Uint32 (i8*, %TName_List_String*)*, i8* }* %ll
+  %"$ll_fptr_132" = extractvalue { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$ll_131", 0
+  %"$ll_envptr_133" = extractvalue { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$ll_131", 1
+  %"$ll_call_134" = call %Uint32 %"$ll_fptr_132"(i8* %"$ll_envptr_133", %TName_List_String* %1)
+  store %Uint32 %"$ll_call_134", %Uint32* %"$ll_0"
+  %"$$ll_0_135" = load %Uint32, %Uint32* %"$ll_0"
+  store %Uint32 %"$$ll_0_135", %Uint32* %n
+  %two = alloca %Uint32
+  store %Uint32 { i32 2 }, %Uint32* %two
+  %"$n_136" = load %Uint32, %Uint32* %n
+  %"$two_137" = load %Uint32, %Uint32* %two
+  %"$add_call_138" = call %Uint32 @_add_Uint32(%Uint32 %"$n_136", %Uint32 %"$two_137")
+  store %Uint32 %"$add_call_138", %Uint32* %"$retval_18"
+  %"$$retval_18_139" = load %Uint32, %Uint32* %"$retval_18"
+  ret %Uint32 %"$$retval_18_139"
+}
+
+define internal { %Uint32 (i8*, %TName_List_String*)*, i8* } @"$fundef_15"(%"$$fundef_15_env_98"* %0) {
+entry:
+  %"$$fundef_15_env_list_length_dummy_113" = getelementptr inbounds %"$$fundef_15_env_98", %"$$fundef_15_env_98"* %0, i32 0, i32 0
+  %"$list_length_dummy_envload_114" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_15_env_list_length_dummy_113"
+  %list_length_dummy = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$list_length_dummy_envload_114", { i8*, i8* }** %list_length_dummy
+  %"$retval_16" = alloca { %Uint32 (i8*, %TName_List_String*)*, i8* }
+  %"$$fundef_17_envp_115_load" = load i8*, i8** @_execptr
+  %"$$fundef_17_envp_115_salloc" = call i8* @_salloc(i8* %"$$fundef_17_envp_115_load", i64 8)
+  %"$$fundef_17_envp_115" = bitcast i8* %"$$fundef_17_envp_115_salloc" to %"$$fundef_17_env_97"*
+  %"$$fundef_17_env_voidp_117" = bitcast %"$$fundef_17_env_97"* %"$$fundef_17_envp_115" to i8*
+  %"$$fundef_17_cloval_118" = insertvalue { %Uint32 (i8*, %TName_List_String*)*, i8* } { %Uint32 (i8*, %TName_List_String*)* bitcast (%Uint32 (%"$$fundef_17_env_97"*, %TName_List_String*)* @"$fundef_17" to %Uint32 (i8*, %TName_List_String*)*), i8* undef }, i8* %"$$fundef_17_env_voidp_117", 1
+  %"$$fundef_17_env_list_length_dummy_119" = getelementptr inbounds %"$$fundef_17_env_97", %"$$fundef_17_env_97"* %"$$fundef_17_envp_115", i32 0, i32 0
+  %"$list_length_dummy_120" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  store { i8*, i8* }* %"$list_length_dummy_120", { i8*, i8* }** %"$$fundef_17_env_list_length_dummy_119"
+  store { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$$fundef_17_cloval_118", { %Uint32 (i8*, %TName_List_String*)*, i8* }* %"$retval_16"
+  %"$$retval_16_121" = load { %Uint32 (i8*, %TName_List_String*)*, i8* }, { %Uint32 (i8*, %TName_List_String*)*, i8* }* %"$retval_16"
+  ret { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$$retval_16_121"
+}
+
+define internal %Uint32 @"$fundef_13"(%"$$fundef_13_env_99"* %0, %TName_List_ByStr20* %1) {
+entry:
+  %"$retval_14" = alloca %Uint32
+  store %Uint32 zeroinitializer, %Uint32* %"$retval_14"
+  %"$$retval_14_112" = load %Uint32, %Uint32* %"$retval_14"
+  ret %Uint32 %"$$retval_14_112"
+}
+
+define internal { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } @"$fundef_11"(%"$$fundef_11_env_100"* %0) {
+entry:
+  %"$retval_12" = alloca { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }
+  store { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } { %Uint32 (i8*, %TName_List_ByStr20*)* bitcast (%Uint32 (%"$$fundef_13_env_99"*, %TName_List_ByStr20*)* @"$fundef_13" to %Uint32 (i8*, %TName_List_ByStr20*)*), i8* null }, { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }* %"$retval_12"
+  %"$$retval_12_111" = load { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }, { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }* %"$retval_12"
+  ret { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$$retval_12_111"
+}
+
+define internal %Uint32 @"$fundef_9"(%"$$fundef_9_env_101"* %0, %TName_List_String* %1) {
+entry:
+  %"$retval_10" = alloca %Uint32
+  store %Uint32 zeroinitializer, %Uint32* %"$retval_10"
+  %"$$retval_10_107" = load %Uint32, %Uint32* %"$retval_10"
+  ret %Uint32 %"$$retval_10_107"
+}
+
+define internal { %Uint32 (i8*, %TName_List_String*)*, i8* } @"$fundef_7"(%"$$fundef_7_env_102"* %0) {
+entry:
+  %"$retval_8" = alloca { %Uint32 (i8*, %TName_List_String*)*, i8* }
+  store { %Uint32 (i8*, %TName_List_String*)*, i8* } { %Uint32 (i8*, %TName_List_String*)* bitcast (%Uint32 (%"$$fundef_9_env_101"*, %TName_List_String*)* @"$fundef_9" to %Uint32 (i8*, %TName_List_String*)*), i8* null }, { %Uint32 (i8*, %TName_List_String*)*, i8* }* %"$retval_8"
+  %"$$retval_8_106" = load { %Uint32 (i8*, %TName_List_String*)*, i8* }, { %Uint32 (i8*, %TName_List_String*)*, i8* }* %"$retval_8"
+  ret { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$$retval_8_106"
+}
+
+declare i8* @_salloc(i8*, i64)
+
+declare %Uint32 @_add_Uint32(%Uint32, %Uint32)
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal %Uint32 @"$scilla_expr_198"(i8* %0) {
+entry:
+  %"$expr_6" = alloca %Uint32
+  %list_length_dummy = alloca { i8*, i8* }*
+  store { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* } { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)* bitcast ({ %Uint32 (i8*, %TName_List_String*)*, i8* } (%"$$fundef_7_env_102"*)* @"$fundef_7" to { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*), i8* null }, { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_205" to { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }*)
+  store { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* } { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)* bitcast ({ %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (%"$$fundef_11_env_100"*)* @"$fundef_11" to { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*), i8* null }, { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_205", i32 0, i32 1) to { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_205", i32 0, i32 0), { i8*, i8* }** %list_length_dummy
+  %list_length2 = alloca { i8*, i8* }*
+  %"$$fundef_15_envp_206_load" = load i8*, i8** @_execptr
+  %"$$fundef_15_envp_206_salloc" = call i8* @_salloc(i8* %"$$fundef_15_envp_206_load", i64 8)
+  %"$$fundef_15_envp_206" = bitcast i8* %"$$fundef_15_envp_206_salloc" to %"$$fundef_15_env_98"*
+  %"$$fundef_15_env_voidp_208" = bitcast %"$$fundef_15_env_98"* %"$$fundef_15_envp_206" to i8*
+  %"$$fundef_15_cloval_209" = insertvalue { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* } { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)* bitcast ({ %Uint32 (i8*, %TName_List_String*)*, i8* } (%"$$fundef_15_env_98"*)* @"$fundef_15" to { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*), i8* undef }, i8* %"$$fundef_15_env_voidp_208", 1
+  %"$$fundef_15_env_list_length_dummy_210" = getelementptr inbounds %"$$fundef_15_env_98", %"$$fundef_15_env_98"* %"$$fundef_15_envp_206", i32 0, i32 0
+  %"$list_length_dummy_211" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  store { i8*, i8* }* %"$list_length_dummy_211", { i8*, i8* }** %"$$fundef_15_env_list_length_dummy_210"
+  %"$$fundef_19_env_voidp_213" = bitcast %"$$fundef_15_env_98"* %"$$fundef_15_envp_206" to i8*
+  %"$$fundef_19_cloval_214" = insertvalue { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* } { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)* bitcast ({ %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (%"$$fundef_19_env_96"*)* @"$fundef_19" to { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*), i8* undef }, i8* %"$$fundef_19_env_voidp_213", 1
+  store { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* } %"$$fundef_15_cloval_209", { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_215" to { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }*)
+  store { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* } %"$$fundef_19_cloval_214", { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_215", i32 0, i32 1) to { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_215", i32 0, i32 0), { i8*, i8* }** %list_length2
+  %t = alloca { { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)*, i8* }
+  store { { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)*, i8* } { { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)* bitcast ({ { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (%"$$fundef_23_env_94"*, %Bool*)* @"$fundef_23" to { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)*), i8* null }, { { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)*, i8* }* %t
+  %true = alloca %Bool*
+  %"$adtval_219_load" = load i8*, i8** @_execptr
+  %"$adtval_219_salloc" = call i8* @_salloc(i8* %"$adtval_219_load", i64 1)
+  %"$adtval_219" = bitcast i8* %"$adtval_219_salloc" to %True*
+  %"$adtgep_220" = getelementptr inbounds %True, %True* %"$adtval_219", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_220"
+  %"$adtptr_221" = bitcast %True* %"$adtval_219" to %Bool*
+  store %Bool* %"$adtptr_221", %Bool** %true
+  %f = alloca { i8*, i8* }*
+  %"$t_1" = alloca { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  %"$t_222" = load { { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)*, i8* }, { { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)*, i8* }* %t
+  %"$t_fptr_223" = extractvalue { { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)*, i8* } %"$t_222", 0
+  %"$t_envptr_224" = extractvalue { { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*, %Bool*)*, i8* } %"$t_222", 1
+  %"$true_225" = load %Bool*, %Bool** %true
+  %"$t_call_226" = call { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_fptr_223"(i8* %"$t_envptr_224", %Bool* %"$true_225")
+  store { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_call_226", { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$t_1"
+  %"$t_2" = alloca { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* }
+  %"$$t_1_227" = load { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$t_1"
+  %"$$t_1_fptr_228" = extractvalue { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$t_1_227", 0
+  %"$$t_1_envptr_229" = extractvalue { { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$t_1_227", 1
+  %"$list_length_dummy_230" = load { i8*, i8* }*, { i8*, i8* }** %list_length_dummy
+  %"$$t_1_call_231" = call { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } %"$$t_1_fptr_228"(i8* %"$$t_1_envptr_229", { i8*, i8* }* %"$list_length_dummy_230")
+  store { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } %"$$t_1_call_231", { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* }* %"$t_2"
+  %"$t_3" = alloca { i8*, i8* }*
+  %"$$t_2_232" = load { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* }, { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* }* %"$t_2"
+  %"$$t_2_fptr_233" = extractvalue { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } %"$$t_2_232", 0
+  %"$$t_2_envptr_234" = extractvalue { { i8*, i8* }* (i8*, { i8*, i8* }*)*, i8* } %"$$t_2_232", 1
+  %"$list_length2_235" = load { i8*, i8* }*, { i8*, i8* }** %list_length2
+  %"$$t_2_call_236" = call { i8*, i8* }* %"$$t_2_fptr_233"(i8* %"$$t_2_envptr_234", { i8*, i8* }* %"$list_length2_235")
+  store { i8*, i8* }* %"$$t_2_call_236", { i8*, i8* }** %"$t_3"
+  %"$$t_3_237" = load { i8*, i8* }*, { i8*, i8* }** %"$t_3"
+  store { i8*, i8* }* %"$$t_3_237", { i8*, i8* }** %f
+  %f_string = alloca { %Uint32 (i8*, %TName_List_String*)*, i8* }
+  %"$f_238" = load { i8*, i8* }*, { i8*, i8* }** %f
+  %"$f_239" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$f_238", i32 0
+  %"$f_240" = bitcast { i8*, i8* }* %"$f_239" to { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }*
+  %"$f_241" = load { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }, { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* }* %"$f_240"
+  %"$f_fptr_242" = extractvalue { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* } %"$f_241", 0
+  %"$f_envptr_243" = extractvalue { { %Uint32 (i8*, %TName_List_String*)*, i8* } (i8*)*, i8* } %"$f_241", 1
+  %"$f_call_244" = call { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$f_fptr_242"(i8* %"$f_envptr_243")
+  store { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$f_call_244", { %Uint32 (i8*, %TName_List_String*)*, i8* }* %f_string
+  %f_bystr20 = alloca { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }
+  %"$f_245" = load { i8*, i8* }*, { i8*, i8* }** %f
+  %"$f_246" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$f_245", i32 1
+  %"$f_247" = bitcast { i8*, i8* }* %"$f_246" to { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }*
+  %"$f_248" = load { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }, { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* }* %"$f_247"
+  %"$f_fptr_249" = extractvalue { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* } %"$f_248", 0
+  %"$f_envptr_250" = extractvalue { { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } (i8*)*, i8* } %"$f_248", 1
+  %"$f_call_251" = call { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$f_fptr_249"(i8* %"$f_envptr_250")
+  store { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$f_call_251", { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }* %f_bystr20
+  %nil_string = alloca %TName_List_String*
+  %"$adtval_252_load" = load i8*, i8** @_execptr
+  %"$adtval_252_salloc" = call i8* @_salloc(i8* %"$adtval_252_load", i64 1)
+  %"$adtval_252" = bitcast i8* %"$adtval_252_salloc" to %CName_Nil_String*
+  %"$adtgep_253" = getelementptr inbounds %CName_Nil_String, %CName_Nil_String* %"$adtval_252", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_253"
+  %"$adtptr_254" = bitcast %CName_Nil_String* %"$adtval_252" to %TName_List_String*
+  store %TName_List_String* %"$adtptr_254", %TName_List_String** %nil_string
+  %nil_bystr20 = alloca %TName_List_ByStr20*
+  %"$adtval_255_load" = load i8*, i8** @_execptr
+  %"$adtval_255_salloc" = call i8* @_salloc(i8* %"$adtval_255_load", i64 1)
+  %"$adtval_255" = bitcast i8* %"$adtval_255_salloc" to %CName_Nil_ByStr20*
+  %"$adtgep_256" = getelementptr inbounds %CName_Nil_ByStr20, %CName_Nil_ByStr20* %"$adtval_255", i32 0, i32 0
+  store i8 1, i8* %"$adtgep_256"
+  %"$adtptr_257" = bitcast %CName_Nil_ByStr20* %"$adtval_255" to %TName_List_ByStr20*
+  store %TName_List_ByStr20* %"$adtptr_257", %TName_List_ByStr20** %nil_bystr20
+  %a = alloca %Uint32
+  %"$f_string_4" = alloca %Uint32
+  %"$f_string_258" = load { %Uint32 (i8*, %TName_List_String*)*, i8* }, { %Uint32 (i8*, %TName_List_String*)*, i8* }* %f_string
+  %"$f_string_fptr_259" = extractvalue { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$f_string_258", 0
+  %"$f_string_envptr_260" = extractvalue { %Uint32 (i8*, %TName_List_String*)*, i8* } %"$f_string_258", 1
+  %"$nil_string_261" = load %TName_List_String*, %TName_List_String** %nil_string
+  %"$f_string_call_262" = call %Uint32 %"$f_string_fptr_259"(i8* %"$f_string_envptr_260", %TName_List_String* %"$nil_string_261")
+  store %Uint32 %"$f_string_call_262", %Uint32* %"$f_string_4"
+  %"$$f_string_4_263" = load %Uint32, %Uint32* %"$f_string_4"
+  store %Uint32 %"$$f_string_4_263", %Uint32* %a
+  %b = alloca %Uint32
+  %"$f_bystr20_5" = alloca %Uint32
+  %"$f_bystr20_264" = load { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }, { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* }* %f_bystr20
+  %"$f_bystr20_fptr_265" = extractvalue { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$f_bystr20_264", 0
+  %"$f_bystr20_envptr_266" = extractvalue { %Uint32 (i8*, %TName_List_ByStr20*)*, i8* } %"$f_bystr20_264", 1
+  %"$nil_bystr20_267" = load %TName_List_ByStr20*, %TName_List_ByStr20** %nil_bystr20
+  %"$f_bystr20_call_268" = call %Uint32 %"$f_bystr20_fptr_265"(i8* %"$f_bystr20_envptr_266", %TName_List_ByStr20* %"$nil_bystr20_267")
+  store %Uint32 %"$f_bystr20_call_268", %Uint32* %"$f_bystr20_5"
+  %"$$f_bystr20_5_269" = load %Uint32, %Uint32* %"$f_bystr20_5"
+  store %Uint32 %"$$f_bystr20_5_269", %Uint32* %b
+  %"$a_270" = load %Uint32, %Uint32* %a
+  %"$b_271" = load %Uint32, %Uint32* %b
+  %"$add_call_272" = call %Uint32 @_add_Uint32(%Uint32 %"$a_270", %Uint32 %"$b_271")
+  store %Uint32 %"$add_call_272", %Uint32* %"$expr_6"
+  %"$$expr_6_273" = load %Uint32, %Uint32* %"$expr_6"
+  ret %Uint32 %"$$expr_6_273"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$exprval_274" = call %Uint32 @"$scilla_expr_198"(i8* null)
+  %"$pval_275" = alloca %Uint32
+  %"$memvoidcast_276" = bitcast %Uint32* %"$pval_275" to i8*
+  store %Uint32 %"$exprval_274", %Uint32* %"$pval_275"
+  call void @_print_scilla_val(%_TyDescrTy_Typ* @"$TyDescr_Uint32_33", i8* %"$memvoidcast_276")
+  ret void
+}

--- a/tests/codegen/expr/gold/tfun-val.scilexp.gold
+++ b/tests/codegen/expr/gold/tfun-val.scilexp.gold
@@ -1,3 +1,106 @@
-Specializing [codegen/expr/tfun-val.scilexp:2:8] 'C with Int32
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_5" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$TyDescrTy_ADTTyp_27" = type { %TyDescrString, i32, i32, i32, %"$TyDescrTy_ADTTyp_Specl_26"** }
+%TyDescrString = type { i8*, i32 }
+%"$TyDescrTy_ADTTyp_Specl_26" = type { %_TyDescrTy_Typ**, %"$TyDescrTy_ADTTyp_Constr_28"**, %"$TyDescrTy_ADTTyp_27"* }
+%"$TyDescrTy_ADTTyp_Constr_28" = type { %TyDescrString, i32, %_TyDescrTy_Typ** }
+%TName_List_Int32 = type { i8, %CName_Cons_Int32*, %CName_Nil_Int32* }
+%CName_Cons_Int32 = type <{ i8, %Int32, %TName_List_Int32* }>
+%CName_Nil_Int32 = type <{ i8 }>
+%Int32 = type { i32 }
+%"$$fundef_3_env_43" = type {}
+%"$$fundef_1_env_44" = type {}
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_6" = global %"$TyDescrTy_PrimTyp_5" zeroinitializer
+@"$TyDescr_Int32_7" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Int32_Prim_6" to i8*) }
+@"$TyDescr_Uint32_Prim_8" = global %"$TyDescrTy_PrimTyp_5" { i32 1, i32 0 }
+@"$TyDescr_Uint32_9" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Uint32_Prim_8" to i8*) }
+@"$TyDescr_Int64_Prim_10" = global %"$TyDescrTy_PrimTyp_5" { i32 0, i32 1 }
+@"$TyDescr_Int64_11" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Int64_Prim_10" to i8*) }
+@"$TyDescr_Uint64_Prim_12" = global %"$TyDescrTy_PrimTyp_5" { i32 1, i32 1 }
+@"$TyDescr_Uint64_13" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Uint64_Prim_12" to i8*) }
+@"$TyDescr_Int128_Prim_14" = global %"$TyDescrTy_PrimTyp_5" { i32 0, i32 2 }
+@"$TyDescr_Int128_15" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Int128_Prim_14" to i8*) }
+@"$TyDescr_Uint128_Prim_16" = global %"$TyDescrTy_PrimTyp_5" { i32 1, i32 2 }
+@"$TyDescr_Uint128_17" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Uint128_Prim_16" to i8*) }
+@"$TyDescr_Int256_Prim_18" = global %"$TyDescrTy_PrimTyp_5" { i32 0, i32 3 }
+@"$TyDescr_Int256_19" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Int256_Prim_18" to i8*) }
+@"$TyDescr_Uint256_Prim_20" = global %"$TyDescrTy_PrimTyp_5" { i32 1, i32 3 }
+@"$TyDescr_Uint256_21" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Uint256_Prim_20" to i8*) }
+@"$TyDescr_String_Prim_22" = global %"$TyDescrTy_PrimTyp_5" { i32 2, i32 0 }
+@"$TyDescr_String_23" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_String_Prim_22" to i8*) }
+@"$TyDescr_Bystr_Prim_24" = global %"$TyDescrTy_PrimTyp_5" { i32 7, i32 0 }
+@"$TyDescr_Bystr_25" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_5"* @"$TyDescr_Bystr_Prim_24" to i8*) }
+@"$TyDescr_ADT_List_Int32_29" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_26"* @"$TyDescr_List_Int32_ADTTyp_Specl_40" to i8*) }
+@"$TyDescr_List_ADTTyp_31" = unnamed_addr constant %"$TyDescrTy_ADTTyp_27" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_List_42", i32 0, i32 0), i32 4 }, i32 1, i32 2, i32 1, %"$TyDescrTy_ADTTyp_Specl_26"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Specl_26"*], [1 x %"$TyDescrTy_ADTTyp_Specl_26"*]* @"$TyDescr_List_ADTTyp_m_specls_41", i32 0, i32 0) }
+@"$TyDescr_List_Cons_Int32_Constr_m_args_32" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int32_7", %_TyDescrTy_Typ* @"$TyDescr_ADT_List_Int32_29"]
+@"$TyDescr_ADT_Cons_33" = unnamed_addr constant [4 x i8] c"Cons"
+@"$TyDescr_List_Cons_Int32_ADTTyp_Constr_34" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_28" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Cons_33", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Cons_Int32_Constr_m_args_32", i32 0, i32 0) }
+@"$TyDescr_List_Nil_Int32_Constr_m_args_35" = unnamed_addr constant [0 x %_TyDescrTy_Typ*] zeroinitializer
+@"$TyDescr_ADT_Nil_36" = unnamed_addr constant [3 x i8] c"Nil"
+@"$TyDescr_List_Nil_Int32_ADTTyp_Constr_37" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_28" { %TyDescrString { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"$TyDescr_ADT_Nil_36", i32 0, i32 0), i32 3 }, i32 0, %_TyDescrTy_Typ** getelementptr inbounds ([0 x %_TyDescrTy_Typ*], [0 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Nil_Int32_Constr_m_args_35", i32 0, i32 0) }
+@"$TyDescr_List_Int32_ADTTyp_Specl_m_constrs_38" = unnamed_addr constant [2 x %"$TyDescrTy_ADTTyp_Constr_28"*] [%"$TyDescrTy_ADTTyp_Constr_28"* @"$TyDescr_List_Cons_Int32_ADTTyp_Constr_34", %"$TyDescrTy_ADTTyp_Constr_28"* @"$TyDescr_List_Nil_Int32_ADTTyp_Constr_37"]
+@"$TyDescr_List_Int32_ADTTyp_Specl_m_TArgs_39" = unnamed_addr constant [1 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int32_7"]
+@"$TyDescr_List_Int32_ADTTyp_Specl_40" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_26" { %_TyDescrTy_Typ** getelementptr inbounds ([1 x %_TyDescrTy_Typ*], [1 x %_TyDescrTy_Typ*]* @"$TyDescr_List_Int32_ADTTyp_Specl_m_TArgs_39", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_28"** getelementptr inbounds ([2 x %"$TyDescrTy_ADTTyp_Constr_28"*], [2 x %"$TyDescrTy_ADTTyp_Constr_28"*]* @"$TyDescr_List_Int32_ADTTyp_Specl_m_constrs_38", i32 0, i32 0), %"$TyDescrTy_ADTTyp_27"* @"$TyDescr_List_ADTTyp_31" }
+@"$TyDescr_List_ADTTyp_m_specls_41" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Specl_26"*] [%"$TyDescrTy_ADTTyp_Specl_26"* @"$TyDescr_List_Int32_ADTTyp_Specl_40"]
+@"$TyDescr_ADT_List_42" = unnamed_addr constant [4 x i8] c"List"
+@"$dyndisp_60" = global [1 x { i8*, i8* }] zeroinitializer
+
+define internal { %TName_List_Int32* (i8*, %Int32)*, i8* } @"$fundef_3"(%"$$fundef_3_env_43"* %0, { i8*, i8* }* %1) {
+entry:
+  %"$retval_4" = alloca { %TName_List_Int32* (i8*, %Int32)*, i8* }
+  %"$f_49" = getelementptr { i8*, i8* }, { i8*, i8* }* %1, i32 0
+  %"$f_50" = bitcast { i8*, i8* }* %"$f_49" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }*
+  %"$f_51" = load { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* }* %"$f_50"
+  %"$f_fptr_52" = extractvalue { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } %"$f_51", 0
+  %"$f_envptr_53" = extractvalue { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*)*, i8* } %"$f_51", 1
+  %"$f_call_54" = call { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f_fptr_52"(i8* %"$f_envptr_53")
+  store { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$f_call_54", { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_4"
+  %"$$retval_4_55" = load { %TName_List_Int32* (i8*, %Int32)*, i8* }, { %TName_List_Int32* (i8*, %Int32)*, i8* }* %"$retval_4"
+  ret { %TName_List_Int32* (i8*, %Int32)*, i8* } %"$$retval_4_55"
+}
+
+define internal { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } @"$fundef_1"(%"$$fundef_1_env_44"* %0) {
+entry:
+  %"$retval_2" = alloca { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  store { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)* bitcast ({ %TName_List_Int32* (i8*, %Int32)*, i8* } (%"$$fundef_3_env_43"*, { i8*, i8* }*)* @"$fundef_3" to { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*), i8* null }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_2"
+  %"$$retval_2_48" = load { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$retval_2"
+  ret { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$retval_2_48"
+}
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } @"$scilla_expr_56"(i8* %0) {
+entry:
+  %"$expr_0" = alloca { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }
+  %t = alloca { i8*, i8* }*
+  store { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)* bitcast ({ { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (%"$$fundef_1_env_44"*)* @"$fundef_1" to { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*), i8* null }, { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }* bitcast ([1 x { i8*, i8* }]* @"$dyndisp_60" to { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([1 x { i8*, i8* }], [1 x { i8*, i8* }]* @"$dyndisp_60", i32 0, i32 0), { i8*, i8* }** %t
+  %"$t_61" = load { i8*, i8* }*, { i8*, i8* }** %t
+  %"$t_62" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$t_61", i32 0
+  %"$t_63" = bitcast { i8*, i8* }* %"$t_62" to { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }*
+  %"$t_64" = load { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }, { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* }* %"$t_63"
+  %"$t_fptr_65" = extractvalue { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } %"$t_64", 0
+  %"$t_envptr_66" = extractvalue { { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } (i8*)*, i8* } %"$t_64", 1
+  %"$t_call_67" = call { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_fptr_65"(i8* %"$t_envptr_66")
+  store { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$t_call_67", { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$expr_0"
+  %"$$expr_0_68" = load { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }, { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* }* %"$expr_0"
+  ret { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } %"$$expr_0_68"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$cloval_69" = call { { %TName_List_Int32* (i8*, %Int32)*, i8* } (i8*, { i8*, i8* }*)*, i8* } @"$scilla_expr_56"(i8* null)
+  ret void
+}

--- a/tests/codegen/expr/gold/tname_clash.scilexp.gold
+++ b/tests/codegen/expr/gold/tname_clash.scilexp.gold
@@ -1,5 +1,202 @@
-Specializing [codegen/expr/tname_clash.scilexp:2:8] 'A with Int32
-Specializing [codegen/expr/tname_clash.scilexp:3:8] 'B with Int64
-Specializing [codegen/expr/tname_clash.scilexp:10:8] 'B with Int32
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_13" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$TyDescrTy_ADTTyp_35" = type { %TyDescrString, i32, i32, i32, %"$TyDescrTy_ADTTyp_Specl_34"** }
+%TyDescrString = type { i8*, i32 }
+%"$TyDescrTy_ADTTyp_Specl_34" = type { %_TyDescrTy_Typ**, %"$TyDescrTy_ADTTyp_Constr_36"**, %"$TyDescrTy_ADTTyp_35"* }
+%"$TyDescrTy_ADTTyp_Constr_36" = type { %TyDescrString, i32, %_TyDescrTy_Typ** }
+%"$$fundef_11_env_48" = type { { i8*, i8* }* }
+%TName_Pair_Int32_Int64 = type { i8, %CName_Pair_Int32_Int64* }
+%CName_Pair_Int32_Int64 = type <{ i8, %Int32, %Int64 }>
+%Int32 = type { i32 }
+%"$$fundef_9_env_49" = type { %Int32 }
+%Int64 = type { i64 }
+%"$$fundef_7_env_50" = type {}
+%"$$fundef_5_env_51" = type {}
+%"$$fundef_3_env_52" = type {}
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_14" = global %"$TyDescrTy_PrimTyp_13" zeroinitializer
+@"$TyDescr_Int32_15" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Int32_Prim_14" to i8*) }
+@"$TyDescr_Uint32_Prim_16" = global %"$TyDescrTy_PrimTyp_13" { i32 1, i32 0 }
+@"$TyDescr_Uint32_17" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Uint32_Prim_16" to i8*) }
+@"$TyDescr_Int64_Prim_18" = global %"$TyDescrTy_PrimTyp_13" { i32 0, i32 1 }
+@"$TyDescr_Int64_19" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Int64_Prim_18" to i8*) }
+@"$TyDescr_Uint64_Prim_20" = global %"$TyDescrTy_PrimTyp_13" { i32 1, i32 1 }
+@"$TyDescr_Uint64_21" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Uint64_Prim_20" to i8*) }
+@"$TyDescr_Int128_Prim_22" = global %"$TyDescrTy_PrimTyp_13" { i32 0, i32 2 }
+@"$TyDescr_Int128_23" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Int128_Prim_22" to i8*) }
+@"$TyDescr_Uint128_Prim_24" = global %"$TyDescrTy_PrimTyp_13" { i32 1, i32 2 }
+@"$TyDescr_Uint128_25" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Uint128_Prim_24" to i8*) }
+@"$TyDescr_Int256_Prim_26" = global %"$TyDescrTy_PrimTyp_13" { i32 0, i32 3 }
+@"$TyDescr_Int256_27" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Int256_Prim_26" to i8*) }
+@"$TyDescr_Uint256_Prim_28" = global %"$TyDescrTy_PrimTyp_13" { i32 1, i32 3 }
+@"$TyDescr_Uint256_29" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Uint256_Prim_28" to i8*) }
+@"$TyDescr_String_Prim_30" = global %"$TyDescrTy_PrimTyp_13" { i32 2, i32 0 }
+@"$TyDescr_String_31" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_String_Prim_30" to i8*) }
+@"$TyDescr_Bystr_Prim_32" = global %"$TyDescrTy_PrimTyp_13" { i32 7, i32 0 }
+@"$TyDescr_Bystr_33" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_13"* @"$TyDescr_Bystr_Prim_32" to i8*) }
+@"$TyDescr_ADT_Pair_Int32_Int64_37" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_34"* @"$TyDescr_Pair_Int32_Int64_ADTTyp_Specl_45" to i8*) }
+@"$TyDescr_Pair_ADTTyp_39" = unnamed_addr constant %"$TyDescrTy_ADTTyp_35" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_47", i32 0, i32 0), i32 4 }, i32 2, i32 1, i32 1, %"$TyDescrTy_ADTTyp_Specl_34"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Specl_34"*], [1 x %"$TyDescrTy_ADTTyp_Specl_34"*]* @"$TyDescr_Pair_ADTTyp_m_specls_46", i32 0, i32 0) }
+@"$TyDescr_Pair_Pair_Int32_Int64_Constr_m_args_40" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int32_15", %_TyDescrTy_Typ* @"$TyDescr_Int64_19"]
+@"$TyDescr_ADT_Pair_41" = unnamed_addr constant [4 x i8] c"Pair"
+@"$TyDescr_Pair_Pair_Int32_Int64_ADTTyp_Constr_42" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_36" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_41", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_Int32_Int64_Constr_m_args_40", i32 0, i32 0) }
+@"$TyDescr_Pair_Int32_Int64_ADTTyp_Specl_m_constrs_43" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Constr_36"*] [%"$TyDescrTy_ADTTyp_Constr_36"* @"$TyDescr_Pair_Pair_Int32_Int64_ADTTyp_Constr_42"]
+@"$TyDescr_Pair_Int32_Int64_ADTTyp_Specl_m_TArgs_44" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Int32_15", %_TyDescrTy_Typ* @"$TyDescr_Int64_19"]
+@"$TyDescr_Pair_Int32_Int64_ADTTyp_Specl_45" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_34" { %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Int32_Int64_ADTTyp_Specl_m_TArgs_44", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_36"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Constr_36"*], [1 x %"$TyDescrTy_ADTTyp_Constr_36"*]* @"$TyDescr_Pair_Int32_Int64_ADTTyp_Specl_m_constrs_43", i32 0, i32 0), %"$TyDescrTy_ADTTyp_35"* @"$TyDescr_Pair_ADTTyp_39" }
+@"$TyDescr_Pair_ADTTyp_m_specls_46" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Specl_34"*] [%"$TyDescrTy_ADTTyp_Specl_34"* @"$TyDescr_Pair_Int32_Int64_ADTTyp_Specl_45"]
+@"$TyDescr_ADT_Pair_47" = unnamed_addr constant [4 x i8] c"Pair"
+@"$dyndisp_56" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_91" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_98" = global [2 x { i8*, i8* }] zeroinitializer
+
+define internal { i8*, i8* }* @"$fundef_11"(%"$$fundef_11_env_48"* %0) {
+entry:
+  %"$$fundef_11_env_tf_77" = getelementptr inbounds %"$$fundef_11_env_48", %"$$fundef_11_env_48"* %0, i32 0, i32 0
+  %"$tf_envload_78" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_11_env_tf_77"
+  %tf = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$tf_envload_78", { i8*, i8* }** %tf
+  %"$retval_12" = alloca { i8*, i8* }*
+  %"$tf_79" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  %"$tf_80" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_79", i32 0
+  %"$tf_81" = bitcast { i8*, i8* }* %"$tf_80" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf_82" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf_81"
+  %"$tf_fptr_83" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_82", 0
+  %"$tf_envptr_84" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_82", 1
+  %"$tf_call_85" = call { i8*, i8* }* %"$tf_fptr_83"(i8* %"$tf_envptr_84")
+  store { i8*, i8* }* %"$tf_call_85", { i8*, i8* }** %"$retval_12"
+  %"$$retval_12_86" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_12"
+  ret { i8*, i8* }* %"$$retval_12_86"
+}
+
+define internal %TName_Pair_Int32_Int64* @"$fundef_9"(%"$$fundef_9_env_49"* %0, %Int64 %1) {
+entry:
+  %"$$fundef_9_env_a_68" = getelementptr inbounds %"$$fundef_9_env_49", %"$$fundef_9_env_49"* %0, i32 0, i32 0
+  %"$a_envload_69" = load %Int32, %Int32* %"$$fundef_9_env_a_68"
+  %a = alloca %Int32
+  store %Int32 %"$a_envload_69", %Int32* %a
+  %"$retval_10" = alloca %TName_Pair_Int32_Int64*
+  %"$a_70" = load %Int32, %Int32* %a
+  %"$adtval_71_load" = load i8*, i8** @_execptr
+  %"$adtval_71_salloc" = call i8* @_salloc(i8* %"$adtval_71_load", i64 13)
+  %"$adtval_71" = bitcast i8* %"$adtval_71_salloc" to %CName_Pair_Int32_Int64*
+  %"$adtgep_72" = getelementptr inbounds %CName_Pair_Int32_Int64, %CName_Pair_Int32_Int64* %"$adtval_71", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_72"
+  %"$adtgep_73" = getelementptr inbounds %CName_Pair_Int32_Int64, %CName_Pair_Int32_Int64* %"$adtval_71", i32 0, i32 1
+  store %Int32 %"$a_70", %Int32* %"$adtgep_73"
+  %"$adtgep_74" = getelementptr inbounds %CName_Pair_Int32_Int64, %CName_Pair_Int32_Int64* %"$adtval_71", i32 0, i32 2
+  store %Int64 %1, %Int64* %"$adtgep_74"
+  %"$adtptr_75" = bitcast %CName_Pair_Int32_Int64* %"$adtval_71" to %TName_Pair_Int32_Int64*
+  store %TName_Pair_Int32_Int64* %"$adtptr_75", %TName_Pair_Int32_Int64** %"$retval_10"
+  %"$$retval_10_76" = load %TName_Pair_Int32_Int64*, %TName_Pair_Int32_Int64** %"$retval_10"
+  ret %TName_Pair_Int32_Int64* %"$$retval_10_76"
+}
+
+define internal { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } @"$fundef_7"(%"$$fundef_7_env_50"* %0, %Int32 %1) {
+entry:
+  %"$retval_8" = alloca { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* }
+  %"$$fundef_9_envp_62_load" = load i8*, i8** @_execptr
+  %"$$fundef_9_envp_62_salloc" = call i8* @_salloc(i8* %"$$fundef_9_envp_62_load", i64 4)
+  %"$$fundef_9_envp_62" = bitcast i8* %"$$fundef_9_envp_62_salloc" to %"$$fundef_9_env_49"*
+  %"$$fundef_9_env_voidp_64" = bitcast %"$$fundef_9_env_49"* %"$$fundef_9_envp_62" to i8*
+  %"$$fundef_9_cloval_65" = insertvalue { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } { %TName_Pair_Int32_Int64* (i8*, %Int64)* bitcast (%TName_Pair_Int32_Int64* (%"$$fundef_9_env_49"*, %Int64)* @"$fundef_9" to %TName_Pair_Int32_Int64* (i8*, %Int64)*), i8* undef }, i8* %"$$fundef_9_env_voidp_64", 1
+  %"$$fundef_9_env_a_66" = getelementptr inbounds %"$$fundef_9_env_49", %"$$fundef_9_env_49"* %"$$fundef_9_envp_62", i32 0, i32 0
+  store %Int32 %1, %Int32* %"$$fundef_9_env_a_66"
+  store { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } %"$$fundef_9_cloval_65", { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* }* %"$retval_8"
+  %"$$retval_8_67" = load { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* }, { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* }* %"$retval_8"
+  ret { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } %"$$retval_8_67"
+}
+
+define internal { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } @"$fundef_5"(%"$$fundef_5_env_51"* %0) {
+entry:
+  %"$retval_6" = alloca { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* }
+  store { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)* bitcast ({ %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (%"$$fundef_7_env_50"*, %Int32)* @"$fundef_7" to { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*), i8* null }, { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* }* %"$retval_6"
+  %"$$retval_6_61" = load { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* }, { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* }* %"$retval_6"
+  ret { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } %"$$retval_6_61"
+}
+
+define internal { i8*, i8* }* @"$fundef_3"(%"$$fundef_3_env_52"* %0) {
+entry:
+  %"$retval_4" = alloca { i8*, i8* }*
+  store { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*, i8* } { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)* bitcast ({ { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (%"$$fundef_5_env_51"*)* @"$fundef_5" to { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*), i8* null }, { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_56", i32 0, i32 1) to { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_56", i32 0, i32 0), { i8*, i8* }** %"$retval_4"
+  %"$$retval_4_57" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_4"
+  ret { i8*, i8* }* %"$$retval_4_57"
+}
+
+declare i8* @_salloc(i8*, i64)
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal %TName_Pair_Int32_Int64* @"$scilla_expr_87"(i8* %0) {
+entry:
+  %"$expr_2" = alloca %TName_Pair_Int32_Int64*
+  %tf = alloca { i8*, i8* }*
+  store { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_3_env_52"*)* @"$fundef_3" to { i8*, i8* }* (i8*)*), i8* null }, { { i8*, i8* }* (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_91" to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_91", i32 0, i32 0), { i8*, i8* }** %tf
+  %tf2 = alloca { i8*, i8* }*
+  %"$$fundef_11_envp_92_load" = load i8*, i8** @_execptr
+  %"$$fundef_11_envp_92_salloc" = call i8* @_salloc(i8* %"$$fundef_11_envp_92_load", i64 8)
+  %"$$fundef_11_envp_92" = bitcast i8* %"$$fundef_11_envp_92_salloc" to %"$$fundef_11_env_48"*
+  %"$$fundef_11_env_voidp_94" = bitcast %"$$fundef_11_env_48"* %"$$fundef_11_envp_92" to i8*
+  %"$$fundef_11_cloval_95" = insertvalue { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_11_env_48"*)* @"$fundef_11" to { i8*, i8* }* (i8*)*), i8* undef }, i8* %"$$fundef_11_env_voidp_94", 1
+  %"$$fundef_11_env_tf_96" = getelementptr inbounds %"$$fundef_11_env_48", %"$$fundef_11_env_48"* %"$$fundef_11_envp_92", i32 0, i32 0
+  %"$tf_97" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  store { i8*, i8* }* %"$tf_97", { i8*, i8* }** %"$$fundef_11_env_tf_96"
+  store { { i8*, i8* }* (i8*)*, i8* } %"$$fundef_11_cloval_95", { { i8*, i8* }* (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_98" to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_98", i32 0, i32 0), { i8*, i8* }** %tf2
+  %f = alloca { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* }
+  %"$tf2_99" = load { i8*, i8* }*, { i8*, i8* }** %tf2
+  %"$tf2_100" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf2_99", i32 0
+  %"$tf2_101" = bitcast { i8*, i8* }* %"$tf2_100" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf2_102" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf2_101"
+  %"$tf2_fptr_103" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf2_102", 0
+  %"$tf2_envptr_104" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf2_102", 1
+  %"$tf2_call_105" = call { i8*, i8* }* %"$tf2_fptr_103"(i8* %"$tf2_envptr_104")
+  %"$tf2_106" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf2_call_105", i32 1
+  %"$tf2_107" = bitcast { i8*, i8* }* %"$tf2_106" to { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*, i8* }*
+  %"$tf2_108" = load { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*, i8* }, { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*, i8* }* %"$tf2_107"
+  %"$tf2_fptr_109" = extractvalue { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*, i8* } %"$tf2_108", 0
+  %"$tf2_envptr_110" = extractvalue { { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } (i8*)*, i8* } %"$tf2_108", 1
+  %"$tf2_call_111" = call { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } %"$tf2_fptr_109"(i8* %"$tf2_envptr_110")
+  store { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } %"$tf2_call_111", { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* }* %f
+  %one = alloca %Int32
+  store %Int32 { i32 1 }, %Int32* %one
+  %two = alloca %Int64
+  store %Int64 { i64 2 }, %Int64* %two
+  %"$f_0" = alloca { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* }
+  %"$f_112" = load { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* }, { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* }* %f
+  %"$f_fptr_113" = extractvalue { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } %"$f_112", 0
+  %"$f_envptr_114" = extractvalue { { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } (i8*, %Int32)*, i8* } %"$f_112", 1
+  %"$one_115" = load %Int32, %Int32* %one
+  %"$f_call_116" = call { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } %"$f_fptr_113"(i8* %"$f_envptr_114", %Int32 %"$one_115")
+  store { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } %"$f_call_116", { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* }* %"$f_0"
+  %"$f_1" = alloca %TName_Pair_Int32_Int64*
+  %"$$f_0_117" = load { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* }, { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* }* %"$f_0"
+  %"$$f_0_fptr_118" = extractvalue { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } %"$$f_0_117", 0
+  %"$$f_0_envptr_119" = extractvalue { %TName_Pair_Int32_Int64* (i8*, %Int64)*, i8* } %"$$f_0_117", 1
+  %"$two_120" = load %Int64, %Int64* %two
+  %"$$f_0_call_121" = call %TName_Pair_Int32_Int64* %"$$f_0_fptr_118"(i8* %"$$f_0_envptr_119", %Int64 %"$two_120")
+  store %TName_Pair_Int32_Int64* %"$$f_0_call_121", %TName_Pair_Int32_Int64** %"$f_1"
+  %"$$f_1_122" = load %TName_Pair_Int32_Int64*, %TName_Pair_Int32_Int64** %"$f_1"
+  store %TName_Pair_Int32_Int64* %"$$f_1_122", %TName_Pair_Int32_Int64** %"$expr_2"
+  %"$$expr_2_123" = load %TName_Pair_Int32_Int64*, %TName_Pair_Int32_Int64** %"$expr_2"
+  ret %TName_Pair_Int32_Int64* %"$$expr_2_123"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$exprval_124" = call %TName_Pair_Int32_Int64* @"$scilla_expr_87"(i8* null)
+  %"$memvoidcast_125" = bitcast %TName_Pair_Int32_Int64* %"$exprval_124" to i8*
+  call void @_print_scilla_val(%_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_Int32_Int64_37", i8* %"$memvoidcast_125")
+  ret void
+}

--- a/tests/codegen/expr/gold/typ-inst.scilexp.gold
+++ b/tests/codegen/expr/gold/typ-inst.scilexp.gold
@@ -1,3 +1,96 @@
-Specializing [codegen/expr/typ-inst.scilexp:2:8] 'A with Uint32
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_6" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$$fundef_4_env_31" = type {}
+%Uint32 = type { i32 }
+%"$$fundef_2_env_32" = type {}
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_7" = global %"$TyDescrTy_PrimTyp_6" zeroinitializer
+@"$TyDescr_Int32_8" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Int32_Prim_7" to i8*) }
+@"$TyDescr_Uint32_Prim_9" = global %"$TyDescrTy_PrimTyp_6" { i32 1, i32 0 }
+@"$TyDescr_Uint32_10" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Uint32_Prim_9" to i8*) }
+@"$TyDescr_Int64_Prim_11" = global %"$TyDescrTy_PrimTyp_6" { i32 0, i32 1 }
+@"$TyDescr_Int64_12" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Int64_Prim_11" to i8*) }
+@"$TyDescr_Uint64_Prim_13" = global %"$TyDescrTy_PrimTyp_6" { i32 1, i32 1 }
+@"$TyDescr_Uint64_14" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Uint64_Prim_13" to i8*) }
+@"$TyDescr_Int128_Prim_15" = global %"$TyDescrTy_PrimTyp_6" { i32 0, i32 2 }
+@"$TyDescr_Int128_16" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Int128_Prim_15" to i8*) }
+@"$TyDescr_Uint128_Prim_17" = global %"$TyDescrTy_PrimTyp_6" { i32 1, i32 2 }
+@"$TyDescr_Uint128_18" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Uint128_Prim_17" to i8*) }
+@"$TyDescr_Int256_Prim_19" = global %"$TyDescrTy_PrimTyp_6" { i32 0, i32 3 }
+@"$TyDescr_Int256_20" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Int256_Prim_19" to i8*) }
+@"$TyDescr_Uint256_Prim_21" = global %"$TyDescrTy_PrimTyp_6" { i32 1, i32 3 }
+@"$TyDescr_Uint256_22" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Uint256_Prim_21" to i8*) }
+@"$TyDescr_String_Prim_23" = global %"$TyDescrTy_PrimTyp_6" { i32 2, i32 0 }
+@"$TyDescr_String_24" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_String_Prim_23" to i8*) }
+@"$TyDescr_Bystr_Prim_25" = global %"$TyDescrTy_PrimTyp_6" { i32 7, i32 0 }
+@"$TyDescr_Bystr_26" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_6"* @"$TyDescr_Bystr_Prim_25" to i8*) }
+@"$dyndisp_42" = global [1 x { i8*, i8* }] zeroinitializer
+
+define internal %Uint32 @"$fundef_4"(%"$$fundef_4_env_31"* %0, %Uint32 %1) {
+entry:
+  %"$retval_5" = alloca %Uint32
+  store %Uint32 %1, %Uint32* %"$retval_5"
+  %"$$retval_5_37" = load %Uint32, %Uint32* %"$retval_5"
+  ret %Uint32 %"$$retval_5_37"
+}
+
+define internal { %Uint32 (i8*, %Uint32)*, i8* } @"$fundef_2"(%"$$fundef_2_env_32"* %0) {
+entry:
+  %"$retval_3" = alloca { %Uint32 (i8*, %Uint32)*, i8* }
+  store { %Uint32 (i8*, %Uint32)*, i8* } { %Uint32 (i8*, %Uint32)* bitcast (%Uint32 (%"$$fundef_4_env_31"*, %Uint32)* @"$fundef_4" to %Uint32 (i8*, %Uint32)*), i8* null }, { %Uint32 (i8*, %Uint32)*, i8* }* %"$retval_3"
+  %"$$retval_3_36" = load { %Uint32 (i8*, %Uint32)*, i8* }, { %Uint32 (i8*, %Uint32)*, i8* }* %"$retval_3"
+  ret { %Uint32 (i8*, %Uint32)*, i8* } %"$$retval_3_36"
+}
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal %Uint32 @"$scilla_expr_38"(i8* %0) {
+entry:
+  %"$expr_1" = alloca %Uint32
+  %tf = alloca { i8*, i8* }*
+  store { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*, i8* } { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)* bitcast ({ %Uint32 (i8*, %Uint32)*, i8* } (%"$$fundef_2_env_32"*)* @"$fundef_2" to { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*), i8* null }, { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*, i8* }* bitcast ([1 x { i8*, i8* }]* @"$dyndisp_42" to { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([1 x { i8*, i8* }], [1 x { i8*, i8* }]* @"$dyndisp_42", i32 0, i32 0), { i8*, i8* }** %tf
+  %t = alloca { %Uint32 (i8*, %Uint32)*, i8* }
+  %"$tf_43" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  %"$tf_44" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_43", i32 0
+  %"$tf_45" = bitcast { i8*, i8* }* %"$tf_44" to { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*, i8* }*
+  %"$tf_46" = load { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*, i8* }, { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*, i8* }* %"$tf_45"
+  %"$tf_fptr_47" = extractvalue { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf_46", 0
+  %"$tf_envptr_48" = extractvalue { { %Uint32 (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf_46", 1
+  %"$tf_call_49" = call { %Uint32 (i8*, %Uint32)*, i8* } %"$tf_fptr_47"(i8* %"$tf_envptr_48")
+  store { %Uint32 (i8*, %Uint32)*, i8* } %"$tf_call_49", { %Uint32 (i8*, %Uint32)*, i8* }* %t
+  %one = alloca %Uint32
+  store %Uint32 { i32 1 }, %Uint32* %one
+  %"$t_0" = alloca %Uint32
+  %"$t_50" = load { %Uint32 (i8*, %Uint32)*, i8* }, { %Uint32 (i8*, %Uint32)*, i8* }* %t
+  %"$t_fptr_51" = extractvalue { %Uint32 (i8*, %Uint32)*, i8* } %"$t_50", 0
+  %"$t_envptr_52" = extractvalue { %Uint32 (i8*, %Uint32)*, i8* } %"$t_50", 1
+  %"$one_53" = load %Uint32, %Uint32* %one
+  %"$t_call_54" = call %Uint32 %"$t_fptr_51"(i8* %"$t_envptr_52", %Uint32 %"$one_53")
+  store %Uint32 %"$t_call_54", %Uint32* %"$t_0"
+  %"$$t_0_55" = load %Uint32, %Uint32* %"$t_0"
+  store %Uint32 %"$$t_0_55", %Uint32* %"$expr_1"
+  %"$$expr_1_56" = load %Uint32, %Uint32* %"$expr_1"
+  ret %Uint32 %"$$expr_1_56"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$exprval_57" = call %Uint32 @"$scilla_expr_38"(i8* null)
+  %"$pval_58" = alloca %Uint32
+  %"$memvoidcast_59" = bitcast %Uint32* %"$pval_58" to i8*
+  store %Uint32 %"$exprval_57", %Uint32* %"$pval_58"
+  call void @_print_scilla_val(%_TyDescrTy_Typ* @"$TyDescr_Uint32_10", i8* %"$memvoidcast_59")
+  ret void
+}

--- a/tests/codegen/expr/gold/typ1-inst.scilexp.gold
+++ b/tests/codegen/expr/gold/typ1-inst.scilexp.gold
@@ -1,0 +1,132 @@
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+%"$TyDescrTy_PrimTyp_11" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$$fundef_9_env_36" = type {}
+%Int32 = type { i32 }
+%"$$fundef_7_env_37" = type {}
+%Uint32 = type { i32 }
+%"$$fundef_5_env_38" = type {}
+%"$$fundef_3_env_39" = type {}
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_12" = global %"$TyDescrTy_PrimTyp_11" zeroinitializer
+@"$TyDescr_Int32_13" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Int32_Prim_12" to i8*) }
+@"$TyDescr_Uint32_Prim_14" = global %"$TyDescrTy_PrimTyp_11" { i32 1, i32 0 }
+@"$TyDescr_Uint32_15" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Uint32_Prim_14" to i8*) }
+@"$TyDescr_Int64_Prim_16" = global %"$TyDescrTy_PrimTyp_11" { i32 0, i32 1 }
+@"$TyDescr_Int64_17" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Int64_Prim_16" to i8*) }
+@"$TyDescr_Uint64_Prim_18" = global %"$TyDescrTy_PrimTyp_11" { i32 1, i32 1 }
+@"$TyDescr_Uint64_19" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Uint64_Prim_18" to i8*) }
+@"$TyDescr_Int128_Prim_20" = global %"$TyDescrTy_PrimTyp_11" { i32 0, i32 2 }
+@"$TyDescr_Int128_21" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Int128_Prim_20" to i8*) }
+@"$TyDescr_Uint128_Prim_22" = global %"$TyDescrTy_PrimTyp_11" { i32 1, i32 2 }
+@"$TyDescr_Uint128_23" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Uint128_Prim_22" to i8*) }
+@"$TyDescr_Int256_Prim_24" = global %"$TyDescrTy_PrimTyp_11" { i32 0, i32 3 }
+@"$TyDescr_Int256_25" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Int256_Prim_24" to i8*) }
+@"$TyDescr_Uint256_Prim_26" = global %"$TyDescrTy_PrimTyp_11" { i32 1, i32 3 }
+@"$TyDescr_Uint256_27" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Uint256_Prim_26" to i8*) }
+@"$TyDescr_String_Prim_28" = global %"$TyDescrTy_PrimTyp_11" { i32 2, i32 0 }
+@"$TyDescr_String_29" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_String_Prim_28" to i8*) }
+@"$TyDescr_Bystr_Prim_30" = global %"$TyDescrTy_PrimTyp_11" { i32 7, i32 0 }
+@"$TyDescr_Bystr_31" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_11"* @"$TyDescr_Bystr_Prim_30" to i8*) }
+@"$dyndisp_43" = global [2 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_58" = global [2 x { i8*, i8* }] zeroinitializer
+
+define internal %Int32 @"$fundef_9"(%"$$fundef_9_env_36"* %0, %Int32 %1) {
+entry:
+  %"$retval_10" = alloca %Int32
+  store %Int32 %1, %Int32* %"$retval_10"
+  %"$$retval_10_53" = load %Int32, %Int32* %"$retval_10"
+  ret %Int32 %"$$retval_10_53"
+}
+
+define internal { %Int32 (i8*, %Int32)*, i8* } @"$fundef_7"(%"$$fundef_7_env_37"* %0, %Uint32 %1) {
+entry:
+  %"$retval_8" = alloca { %Int32 (i8*, %Int32)*, i8* }
+  store { %Int32 (i8*, %Int32)*, i8* } { %Int32 (i8*, %Int32)* bitcast (%Int32 (%"$$fundef_9_env_36"*, %Int32)* @"$fundef_9" to %Int32 (i8*, %Int32)*), i8* null }, { %Int32 (i8*, %Int32)*, i8* }* %"$retval_8"
+  %"$$retval_8_52" = load { %Int32 (i8*, %Int32)*, i8* }, { %Int32 (i8*, %Int32)*, i8* }* %"$retval_8"
+  ret { %Int32 (i8*, %Int32)*, i8* } %"$$retval_8_52"
+}
+
+define internal { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } @"$fundef_5"(%"$$fundef_5_env_38"* %0) {
+entry:
+  %"$retval_6" = alloca { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* }
+  store { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)* bitcast ({ %Int32 (i8*, %Int32)*, i8* } (%"$$fundef_7_env_37"*, %Uint32)* @"$fundef_7" to { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*), i8* null }, { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_6"
+  %"$$retval_6_48" = load { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* }, { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_6"
+  ret { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } %"$$retval_6_48"
+}
+
+define internal { i8*, i8* }* @"$fundef_3"(%"$$fundef_3_env_39"* %0) {
+entry:
+  %"$retval_4" = alloca { i8*, i8* }*
+  store { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)* bitcast ({ { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (%"$$fundef_5_env_38"*)* @"$fundef_5" to { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*), i8* null }, { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_43", i32 0, i32 1) to { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_43", i32 0, i32 0), { i8*, i8* }** %"$retval_4"
+  %"$$retval_4_44" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_4"
+  ret { i8*, i8* }* %"$$retval_4_44"
+}
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal %Int32 @"$scilla_expr_54"(i8* %0) {
+entry:
+  %"$expr_2" = alloca %Int32
+  %tf = alloca { i8*, i8* }*
+  store { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_3_env_39"*)* @"$fundef_3" to { i8*, i8* }* (i8*)*), i8* null }, { { i8*, i8* }* (i8*)*, i8* }* bitcast ([2 x { i8*, i8* }]* @"$dyndisp_58" to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([2 x { i8*, i8* }], [2 x { i8*, i8* }]* @"$dyndisp_58", i32 0, i32 0), { i8*, i8* }** %tf
+  %t = alloca { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* }
+  %"$tf_59" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  %"$tf_60" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_59", i32 0
+  %"$tf_61" = bitcast { i8*, i8* }* %"$tf_60" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf_62" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf_61"
+  %"$tf_fptr_63" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_62", 0
+  %"$tf_envptr_64" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_62", 1
+  %"$tf_call_65" = call { i8*, i8* }* %"$tf_fptr_63"(i8* %"$tf_envptr_64")
+  %"$tf_66" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_call_65", i32 1
+  %"$tf_67" = bitcast { i8*, i8* }* %"$tf_66" to { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*
+  %"$tf_68" = load { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }, { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* %"$tf_67"
+  %"$tf_fptr_69" = extractvalue { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf_68", 0
+  %"$tf_envptr_70" = extractvalue { { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf_68", 1
+  %"$tf_call_71" = call { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } %"$tf_fptr_69"(i8* %"$tf_envptr_70")
+  store { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } %"$tf_call_71", { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* }* %t
+  %one = alloca %Uint32
+  store %Uint32 { i32 1 }, %Uint32* %one
+  %two = alloca %Int32
+  store %Int32 { i32 2 }, %Int32* %two
+  %"$t_0" = alloca { %Int32 (i8*, %Int32)*, i8* }
+  %"$t_72" = load { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* }, { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* }* %t
+  %"$t_fptr_73" = extractvalue { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } %"$t_72", 0
+  %"$t_envptr_74" = extractvalue { { %Int32 (i8*, %Int32)*, i8* } (i8*, %Uint32)*, i8* } %"$t_72", 1
+  %"$one_75" = load %Uint32, %Uint32* %one
+  %"$t_call_76" = call { %Int32 (i8*, %Int32)*, i8* } %"$t_fptr_73"(i8* %"$t_envptr_74", %Uint32 %"$one_75")
+  store { %Int32 (i8*, %Int32)*, i8* } %"$t_call_76", { %Int32 (i8*, %Int32)*, i8* }* %"$t_0"
+  %"$t_1" = alloca %Int32
+  %"$$t_0_77" = load { %Int32 (i8*, %Int32)*, i8* }, { %Int32 (i8*, %Int32)*, i8* }* %"$t_0"
+  %"$$t_0_fptr_78" = extractvalue { %Int32 (i8*, %Int32)*, i8* } %"$$t_0_77", 0
+  %"$$t_0_envptr_79" = extractvalue { %Int32 (i8*, %Int32)*, i8* } %"$$t_0_77", 1
+  %"$two_80" = load %Int32, %Int32* %two
+  %"$$t_0_call_81" = call %Int32 %"$$t_0_fptr_78"(i8* %"$$t_0_envptr_79", %Int32 %"$two_80")
+  store %Int32 %"$$t_0_call_81", %Int32* %"$t_1"
+  %"$$t_1_82" = load %Int32, %Int32* %"$t_1"
+  store %Int32 %"$$t_1_82", %Int32* %"$expr_2"
+  %"$$expr_2_83" = load %Int32, %Int32* %"$expr_2"
+  ret %Int32 %"$$expr_2_83"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$exprval_84" = call %Int32 @"$scilla_expr_54"(i8* null)
+  %"$pval_85" = alloca %Int32
+  %"$memvoidcast_86" = bitcast %Int32* %"$pval_85" to i8*
+  store %Int32 %"$exprval_84", %Int32* %"$pval_85"
+  call void @_print_scilla_val(%_TyDescrTy_Typ* @"$TyDescr_Int32_13", i8* %"$memvoidcast_86")
+  ret void
+}

--- a/tests/codegen/expr/gold/typ2-inst.scilexp.gold
+++ b/tests/codegen/expr/gold/typ2-inst.scilexp.gold
@@ -1,10 +1,419 @@
-Specializing [codegen/expr/typ2-inst.scilexp:2:8] 'A with Uint32
-Specializing [codegen/expr/typ2-inst.scilexp:3:8] 'B with Uint64
-Specializing [codegen/expr/typ2-inst.scilexp:2:8] 'A with String
-Specializing [codegen/expr/typ2-inst.scilexp:3:8] 'B with ByStr20
-Specializing [codegen/expr/typ2-inst.scilexp:10:8] 'A with Uint32
-Specializing [codegen/expr/typ2-inst.scilexp:11:8] 'B with Uint64
-Specializing [codegen/expr/typ2-inst.scilexp:10:8] 'A with String
-Specializing [codegen/expr/typ2-inst.scilexp:11:8] 'B with ByStr20
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_29" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$TyDescrTy_ADTTyp_53" = type { %TyDescrString, i32, i32, i32, %"$TyDescrTy_ADTTyp_Specl_52"** }
+%TyDescrString = type { i8*, i32 }
+%"$TyDescrTy_ADTTyp_Specl_52" = type { %_TyDescrTy_Typ**, %"$TyDescrTy_ADTTyp_Constr_54"**, %"$TyDescrTy_ADTTyp_53"* }
+%"$TyDescrTy_ADTTyp_Constr_54" = type { %TyDescrString, i32, %_TyDescrTy_Typ** }
+%TName_Pair_String_ByStr20 = type { i8, %CName_Pair_String_ByStr20* }
+%CName_Pair_String_ByStr20 = type <{ i8, %String, [20 x i8] }>
+%String = type { i8*, i32 }
+%"$$fundef_27_env_80" = type { { i8*, i8* }* }
+%"$$fundef_25_env_81" = type { { i8*, i8* }* }
+%TName_Pair_Uint32_Uint64 = type { i8, %CName_Pair_Uint32_Uint64* }
+%CName_Pair_Uint32_Uint64 = type <{ i8, %Uint32, %Uint64 }>
+%Uint64 = type { i64 }
+%Uint32 = type { i32 }
+%"$$fundef_23_env_82" = type { { i8*, i8* }* }
+%"$$fundef_21_env_83" = type { { i8*, i8* }* }
+%"$$fundef_19_env_84" = type { %String }
+%"$$fundef_17_env_85" = type {}
+%"$$fundef_15_env_86" = type {}
+%"$$fundef_13_env_87" = type {}
+%"$$fundef_11_env_88" = type { %Uint32 }
+%"$$fundef_9_env_89" = type {}
+%"$$fundef_7_env_90" = type {}
+%"$$fundef_5_env_91" = type {}
+%"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)" = type { i8, %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* }
+%"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)" = type <{ i8, %TName_Pair_Uint32_Uint64*, %TName_Pair_String_ByStr20* }>
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_30" = global %"$TyDescrTy_PrimTyp_29" zeroinitializer
+@"$TyDescr_Int32_31" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int32_Prim_30" to i8*) }
+@"$TyDescr_Uint32_Prim_32" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 0 }
+@"$TyDescr_Uint32_33" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint32_Prim_32" to i8*) }
+@"$TyDescr_Int64_Prim_34" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 1 }
+@"$TyDescr_Int64_35" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int64_Prim_34" to i8*) }
+@"$TyDescr_Uint64_Prim_36" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 1 }
+@"$TyDescr_Uint64_37" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint64_Prim_36" to i8*) }
+@"$TyDescr_Int128_Prim_38" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 2 }
+@"$TyDescr_Int128_39" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int128_Prim_38" to i8*) }
+@"$TyDescr_Uint128_Prim_40" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 2 }
+@"$TyDescr_Uint128_41" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint128_Prim_40" to i8*) }
+@"$TyDescr_Int256_Prim_42" = global %"$TyDescrTy_PrimTyp_29" { i32 0, i32 3 }
+@"$TyDescr_Int256_43" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Int256_Prim_42" to i8*) }
+@"$TyDescr_Uint256_Prim_44" = global %"$TyDescrTy_PrimTyp_29" { i32 1, i32 3 }
+@"$TyDescr_Uint256_45" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Uint256_Prim_44" to i8*) }
+@"$TyDescr_String_Prim_46" = global %"$TyDescrTy_PrimTyp_29" { i32 2, i32 0 }
+@"$TyDescr_String_47" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_String_Prim_46" to i8*) }
+@"$TyDescr_Bystr_Prim_48" = global %"$TyDescrTy_PrimTyp_29" { i32 7, i32 0 }
+@"$TyDescr_Bystr_49" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Bystr_Prim_48" to i8*) }
+@"$TyDescr_Bystr20_Prim_50" = global %"$TyDescrTy_PrimTyp_29" { i32 8, i32 20 }
+@"$TyDescr_Bystr20_51" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_29"* @"$TyDescr_Bystr20_Prim_50" to i8*) }
+@"$TyDescr_ADT_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_55" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Specl_65" to i8*) }
+@"$TyDescr_ADT_Pair_String_ByStr20_56" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_Pair_String_ByStr20_ADTTyp_Specl_71" to i8*) }
+@"$TyDescr_ADT_Pair_Uint32_Uint64_57" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_77" to i8*) }
+@"$TyDescr_Pair_ADTTyp_59" = unnamed_addr constant %"$TyDescrTy_ADTTyp_53" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_79", i32 0, i32 0), i32 4 }, i32 2, i32 1, i32 3, %"$TyDescrTy_ADTTyp_Specl_52"** getelementptr inbounds ([3 x %"$TyDescrTy_ADTTyp_Specl_52"*], [3 x %"$TyDescrTy_ADTTyp_Specl_52"*]* @"$TyDescr_Pair_ADTTyp_m_specls_78", i32 0, i32 0) }
+@"$TyDescr_Pair_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_Constr_m_args_60" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_Uint32_Uint64_57", %_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_String_ByStr20_56"]
+@"$TyDescr_ADT_Pair_61" = unnamed_addr constant [4 x i8] c"Pair"
+@"$TyDescr_Pair_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Constr_62" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_61", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_Constr_m_args_60", i32 0, i32 0) }
+@"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Specl_m_constrs_63" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Constr_54"*] [%"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_Pair_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Constr_62"]
+@"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Specl_m_TArgs_64" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_Uint32_Uint64_57", %_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_String_ByStr20_56"]
+@"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Specl_65" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_52" { %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Specl_m_TArgs_64", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_54"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Constr_54"*], [1 x %"$TyDescrTy_ADTTyp_Constr_54"*]* @"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Specl_m_constrs_63", i32 0, i32 0), %"$TyDescrTy_ADTTyp_53"* @"$TyDescr_Pair_ADTTyp_59" }
+@"$TyDescr_Pair_Pair_String_ByStr20_Constr_m_args_66" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_String_47", %_TyDescrTy_Typ* @"$TyDescr_Bystr20_51"]
+@"$TyDescr_ADT_Pair_67" = unnamed_addr constant [4 x i8] c"Pair"
+@"$TyDescr_Pair_Pair_String_ByStr20_ADTTyp_Constr_68" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_67", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_String_ByStr20_Constr_m_args_66", i32 0, i32 0) }
+@"$TyDescr_Pair_String_ByStr20_ADTTyp_Specl_m_constrs_69" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Constr_54"*] [%"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_Pair_Pair_String_ByStr20_ADTTyp_Constr_68"]
+@"$TyDescr_Pair_String_ByStr20_ADTTyp_Specl_m_TArgs_70" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_String_47", %_TyDescrTy_Typ* @"$TyDescr_Bystr20_51"]
+@"$TyDescr_Pair_String_ByStr20_ADTTyp_Specl_71" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_52" { %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_String_ByStr20_ADTTyp_Specl_m_TArgs_70", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_54"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Constr_54"*], [1 x %"$TyDescrTy_ADTTyp_Constr_54"*]* @"$TyDescr_Pair_String_ByStr20_ADTTyp_Specl_m_constrs_69", i32 0, i32 0), %"$TyDescrTy_ADTTyp_53"* @"$TyDescr_Pair_ADTTyp_59" }
+@"$TyDescr_Pair_Pair_Uint32_Uint64_Constr_m_args_72" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Uint32_33", %_TyDescrTy_Typ* @"$TyDescr_Uint64_37"]
+@"$TyDescr_ADT_Pair_73" = unnamed_addr constant [4 x i8] c"Pair"
+@"$TyDescr_Pair_Pair_Uint32_Uint64_ADTTyp_Constr_74" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_54" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_73", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_Uint32_Uint64_Constr_m_args_72", i32 0, i32 0) }
+@"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_m_constrs_75" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Constr_54"*] [%"$TyDescrTy_ADTTyp_Constr_54"* @"$TyDescr_Pair_Pair_Uint32_Uint64_ADTTyp_Constr_74"]
+@"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_m_TArgs_76" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Uint32_33", %_TyDescrTy_Typ* @"$TyDescr_Uint64_37"]
+@"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_77" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_52" { %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_m_TArgs_76", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_54"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Constr_54"*], [1 x %"$TyDescrTy_ADTTyp_Constr_54"*]* @"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_m_constrs_75", i32 0, i32 0), %"$TyDescrTy_ADTTyp_53"* @"$TyDescr_Pair_ADTTyp_59" }
+@"$TyDescr_Pair_ADTTyp_m_specls_78" = unnamed_addr constant [3 x %"$TyDescrTy_ADTTyp_Specl_52"*] [%"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_ADTTyp_Specl_65", %"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_Pair_String_ByStr20_ADTTyp_Specl_71", %"$TyDescrTy_ADTTyp_Specl_52"* @"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_77"]
+@"$TyDescr_ADT_Pair_79" = unnamed_addr constant [4 x i8] c"Pair"
+@"$dyndisp_95" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_119" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_148" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_174" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_199" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_209" = global [4 x { i8*, i8* }] zeroinitializer
+@"$stringlit_236" = unnamed_addr constant [5 x i8] c"hello"
+
+define internal { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } @"$fundef_27"(%"$$fundef_27_env_80"* %0) {
+entry:
+  %"$$fundef_27_env_tf_176" = getelementptr inbounds %"$$fundef_27_env_80", %"$$fundef_27_env_80"* %0, i32 0, i32 0
+  %"$tf_envload_177" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_27_env_tf_176"
+  %tf = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$tf_envload_177", { i8*, i8* }** %tf
+  %"$retval_28" = alloca { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }
+  %"$tf_178" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  %"$tf_179" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_178", i32 2
+  %"$tf_180" = bitcast { i8*, i8* }* %"$tf_179" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf_181" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf_180"
+  %"$tf_fptr_182" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_181", 0
+  %"$tf_envptr_183" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_181", 1
+  %"$tf_call_184" = call { i8*, i8* }* %"$tf_fptr_182"(i8* %"$tf_envptr_183")
+  %"$tf_185" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_call_184", i32 3
+  %"$tf_186" = bitcast { i8*, i8* }* %"$tf_185" to { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }*
+  %"$tf_187" = load { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }, { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }* %"$tf_186"
+  %"$tf_fptr_188" = extractvalue { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* } %"$tf_187", 0
+  %"$tf_envptr_189" = extractvalue { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* } %"$tf_187", 1
+  %"$tf_call_190" = call { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } %"$tf_fptr_188"(i8* %"$tf_envptr_189")
+  store { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } %"$tf_call_190", { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }* %"$retval_28"
+  %"$$retval_28_191" = load { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }, { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }* %"$retval_28"
+  ret { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } %"$$retval_28_191"
+}
+
+define internal { i8*, i8* }* @"$fundef_25"(%"$$fundef_25_env_81"* %0) {
+entry:
+  %"$$fundef_25_env_tf_166" = getelementptr inbounds %"$$fundef_25_env_81", %"$$fundef_25_env_81"* %0, i32 0, i32 0
+  %"$tf_envload_167" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_25_env_tf_166"
+  %tf = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$tf_envload_167", { i8*, i8* }** %tf
+  %"$retval_26" = alloca { i8*, i8* }*
+  %"$$fundef_27_envp_168_load" = load i8*, i8** @_execptr
+  %"$$fundef_27_envp_168_salloc" = call i8* @_salloc(i8* %"$$fundef_27_envp_168_load", i64 8)
+  %"$$fundef_27_envp_168" = bitcast i8* %"$$fundef_27_envp_168_salloc" to %"$$fundef_27_env_80"*
+  %"$$fundef_27_env_voidp_170" = bitcast %"$$fundef_27_env_80"* %"$$fundef_27_envp_168" to i8*
+  %"$$fundef_27_cloval_171" = insertvalue { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* } { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)* bitcast ({ { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (%"$$fundef_27_env_80"*)* @"$fundef_27" to { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*), i8* undef }, i8* %"$$fundef_27_env_voidp_170", 1
+  %"$$fundef_27_env_tf_172" = getelementptr inbounds %"$$fundef_27_env_80", %"$$fundef_27_env_80"* %"$$fundef_27_envp_168", i32 0, i32 0
+  %"$tf_173" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  store { i8*, i8* }* %"$tf_173", { i8*, i8* }** %"$$fundef_27_env_tf_172"
+  store { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* } %"$$fundef_27_cloval_171", { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_174", i32 0, i32 3) to { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_174", i32 0, i32 0), { i8*, i8* }** %"$retval_26"
+  %"$$retval_26_175" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_26"
+  ret { i8*, i8* }* %"$$retval_26_175"
+}
+
+define internal { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } @"$fundef_23"(%"$$fundef_23_env_82"* %0) {
+entry:
+  %"$$fundef_23_env_tf_150" = getelementptr inbounds %"$$fundef_23_env_82", %"$$fundef_23_env_82"* %0, i32 0, i32 0
+  %"$tf_envload_151" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_23_env_tf_150"
+  %tf = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$tf_envload_151", { i8*, i8* }** %tf
+  %"$retval_24" = alloca { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }
+  %"$tf_152" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  %"$tf_153" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_152", i32 0
+  %"$tf_154" = bitcast { i8*, i8* }* %"$tf_153" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf_155" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf_154"
+  %"$tf_fptr_156" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_155", 0
+  %"$tf_envptr_157" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_155", 1
+  %"$tf_call_158" = call { i8*, i8* }* %"$tf_fptr_156"(i8* %"$tf_envptr_157")
+  %"$tf_159" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_call_158", i32 1
+  %"$tf_160" = bitcast { i8*, i8* }* %"$tf_159" to { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*
+  %"$tf_161" = load { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }, { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* %"$tf_160"
+  %"$tf_fptr_162" = extractvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf_161", 0
+  %"$tf_envptr_163" = extractvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf_161", 1
+  %"$tf_call_164" = call { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$tf_fptr_162"(i8* %"$tf_envptr_163")
+  store { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$tf_call_164", { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_24"
+  %"$$retval_24_165" = load { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }, { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_24"
+  ret { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$$retval_24_165"
+}
+
+define internal { i8*, i8* }* @"$fundef_21"(%"$$fundef_21_env_83"* %0) {
+entry:
+  %"$$fundef_21_env_tf_140" = getelementptr inbounds %"$$fundef_21_env_83", %"$$fundef_21_env_83"* %0, i32 0, i32 0
+  %"$tf_envload_141" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_21_env_tf_140"
+  %tf = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$tf_envload_141", { i8*, i8* }** %tf
+  %"$retval_22" = alloca { i8*, i8* }*
+  %"$$fundef_23_envp_142_load" = load i8*, i8** @_execptr
+  %"$$fundef_23_envp_142_salloc" = call i8* @_salloc(i8* %"$$fundef_23_envp_142_load", i64 8)
+  %"$$fundef_23_envp_142" = bitcast i8* %"$$fundef_23_envp_142_salloc" to %"$$fundef_23_env_82"*
+  %"$$fundef_23_env_voidp_144" = bitcast %"$$fundef_23_env_82"* %"$$fundef_23_envp_142" to i8*
+  %"$$fundef_23_cloval_145" = insertvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)* bitcast ({ { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (%"$$fundef_23_env_82"*)* @"$fundef_23" to { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*), i8* undef }, i8* %"$$fundef_23_env_voidp_144", 1
+  %"$$fundef_23_env_tf_146" = getelementptr inbounds %"$$fundef_23_env_82", %"$$fundef_23_env_82"* %"$$fundef_23_envp_142", i32 0, i32 0
+  %"$tf_147" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  store { i8*, i8* }* %"$tf_147", { i8*, i8* }** %"$$fundef_23_env_tf_146"
+  store { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$$fundef_23_cloval_145", { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_148", i32 0, i32 1) to { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_148", i32 0, i32 0), { i8*, i8* }** %"$retval_22"
+  %"$$retval_22_149" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_22"
+  ret { i8*, i8* }* %"$$retval_22_149"
+}
+
+define internal %TName_Pair_String_ByStr20* @"$fundef_19"(%"$$fundef_19_env_84"* %0, [20 x i8]* %1) {
+entry:
+  %b = load [20 x i8], [20 x i8]* %1
+  %"$$fundef_19_env_a_131" = getelementptr inbounds %"$$fundef_19_env_84", %"$$fundef_19_env_84"* %0, i32 0, i32 0
+  %"$a_envload_132" = load %String, %String* %"$$fundef_19_env_a_131"
+  %a = alloca %String
+  store %String %"$a_envload_132", %String* %a
+  %"$retval_20" = alloca %TName_Pair_String_ByStr20*
+  %"$a_133" = load %String, %String* %a
+  %"$adtval_134_load" = load i8*, i8** @_execptr
+  %"$adtval_134_salloc" = call i8* @_salloc(i8* %"$adtval_134_load", i64 37)
+  %"$adtval_134" = bitcast i8* %"$adtval_134_salloc" to %CName_Pair_String_ByStr20*
+  %"$adtgep_135" = getelementptr inbounds %CName_Pair_String_ByStr20, %CName_Pair_String_ByStr20* %"$adtval_134", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_135"
+  %"$adtgep_136" = getelementptr inbounds %CName_Pair_String_ByStr20, %CName_Pair_String_ByStr20* %"$adtval_134", i32 0, i32 1
+  store %String %"$a_133", %String* %"$adtgep_136"
+  %"$adtgep_137" = getelementptr inbounds %CName_Pair_String_ByStr20, %CName_Pair_String_ByStr20* %"$adtval_134", i32 0, i32 2
+  store [20 x i8] %b, [20 x i8]* %"$adtgep_137"
+  %"$adtptr_138" = bitcast %CName_Pair_String_ByStr20* %"$adtval_134" to %TName_Pair_String_ByStr20*
+  store %TName_Pair_String_ByStr20* %"$adtptr_138", %TName_Pair_String_ByStr20** %"$retval_20"
+  %"$$retval_20_139" = load %TName_Pair_String_ByStr20*, %TName_Pair_String_ByStr20** %"$retval_20"
+  ret %TName_Pair_String_ByStr20* %"$$retval_20_139"
+}
+
+define internal { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } @"$fundef_17"(%"$$fundef_17_env_85"* %0, %String %1) {
+entry:
+  %"$retval_18" = alloca { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* }
+  %"$$fundef_19_envp_125_load" = load i8*, i8** @_execptr
+  %"$$fundef_19_envp_125_salloc" = call i8* @_salloc(i8* %"$$fundef_19_envp_125_load", i64 16)
+  %"$$fundef_19_envp_125" = bitcast i8* %"$$fundef_19_envp_125_salloc" to %"$$fundef_19_env_84"*
+  %"$$fundef_19_env_voidp_127" = bitcast %"$$fundef_19_env_84"* %"$$fundef_19_envp_125" to i8*
+  %"$$fundef_19_cloval_128" = insertvalue { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)* bitcast (%TName_Pair_String_ByStr20* (%"$$fundef_19_env_84"*, [20 x i8]*)* @"$fundef_19" to %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*), i8* undef }, i8* %"$$fundef_19_env_voidp_127", 1
+  %"$$fundef_19_env_a_129" = getelementptr inbounds %"$$fundef_19_env_84", %"$$fundef_19_env_84"* %"$$fundef_19_envp_125", i32 0, i32 0
+  store %String %1, %String* %"$$fundef_19_env_a_129"
+  store { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } %"$$fundef_19_cloval_128", { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* }* %"$retval_18"
+  %"$$retval_18_130" = load { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* }, { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* }* %"$retval_18"
+  ret { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } %"$$retval_18_130"
+}
+
+define internal { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } @"$fundef_15"(%"$$fundef_15_env_86"* %0) {
+entry:
+  %"$retval_16" = alloca { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }
+  store { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)* bitcast ({ %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (%"$$fundef_17_env_85"*, %String)* @"$fundef_17" to { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*), i8* null }, { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }* %"$retval_16"
+  %"$$retval_16_124" = load { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }, { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }* %"$retval_16"
+  ret { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } %"$$retval_16_124"
+}
+
+define internal { i8*, i8* }* @"$fundef_13"(%"$$fundef_13_env_87"* %0) {
+entry:
+  %"$retval_14" = alloca { i8*, i8* }*
+  store { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* } { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)* bitcast ({ { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (%"$$fundef_15_env_86"*)* @"$fundef_15" to { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*), i8* null }, { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_119", i32 0, i32 3) to { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_119", i32 0, i32 0), { i8*, i8* }** %"$retval_14"
+  %"$$retval_14_120" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_14"
+  ret { i8*, i8* }* %"$$retval_14_120"
+}
+
+define internal %TName_Pair_Uint32_Uint64* @"$fundef_11"(%"$$fundef_11_env_88"* %0, %Uint64 %1) {
+entry:
+  %"$$fundef_11_env_a_107" = getelementptr inbounds %"$$fundef_11_env_88", %"$$fundef_11_env_88"* %0, i32 0, i32 0
+  %"$a_envload_108" = load %Uint32, %Uint32* %"$$fundef_11_env_a_107"
+  %a = alloca %Uint32
+  store %Uint32 %"$a_envload_108", %Uint32* %a
+  %"$retval_12" = alloca %TName_Pair_Uint32_Uint64*
+  %"$a_109" = load %Uint32, %Uint32* %a
+  %"$adtval_110_load" = load i8*, i8** @_execptr
+  %"$adtval_110_salloc" = call i8* @_salloc(i8* %"$adtval_110_load", i64 13)
+  %"$adtval_110" = bitcast i8* %"$adtval_110_salloc" to %CName_Pair_Uint32_Uint64*
+  %"$adtgep_111" = getelementptr inbounds %CName_Pair_Uint32_Uint64, %CName_Pair_Uint32_Uint64* %"$adtval_110", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_111"
+  %"$adtgep_112" = getelementptr inbounds %CName_Pair_Uint32_Uint64, %CName_Pair_Uint32_Uint64* %"$adtval_110", i32 0, i32 1
+  store %Uint32 %"$a_109", %Uint32* %"$adtgep_112"
+  %"$adtgep_113" = getelementptr inbounds %CName_Pair_Uint32_Uint64, %CName_Pair_Uint32_Uint64* %"$adtval_110", i32 0, i32 2
+  store %Uint64 %1, %Uint64* %"$adtgep_113"
+  %"$adtptr_114" = bitcast %CName_Pair_Uint32_Uint64* %"$adtval_110" to %TName_Pair_Uint32_Uint64*
+  store %TName_Pair_Uint32_Uint64* %"$adtptr_114", %TName_Pair_Uint32_Uint64** %"$retval_12"
+  %"$$retval_12_115" = load %TName_Pair_Uint32_Uint64*, %TName_Pair_Uint32_Uint64** %"$retval_12"
+  ret %TName_Pair_Uint32_Uint64* %"$$retval_12_115"
+}
+
+define internal { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } @"$fundef_9"(%"$$fundef_9_env_89"* %0, %Uint32 %1) {
+entry:
+  %"$retval_10" = alloca { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }
+  %"$$fundef_11_envp_101_load" = load i8*, i8** @_execptr
+  %"$$fundef_11_envp_101_salloc" = call i8* @_salloc(i8* %"$$fundef_11_envp_101_load", i64 4)
+  %"$$fundef_11_envp_101" = bitcast i8* %"$$fundef_11_envp_101_salloc" to %"$$fundef_11_env_88"*
+  %"$$fundef_11_env_voidp_103" = bitcast %"$$fundef_11_env_88"* %"$$fundef_11_envp_101" to i8*
+  %"$$fundef_11_cloval_104" = insertvalue { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)* bitcast (%TName_Pair_Uint32_Uint64* (%"$$fundef_11_env_88"*, %Uint64)* @"$fundef_11" to %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*), i8* undef }, i8* %"$$fundef_11_env_voidp_103", 1
+  %"$$fundef_11_env_a_105" = getelementptr inbounds %"$$fundef_11_env_88", %"$$fundef_11_env_88"* %"$$fundef_11_envp_101", i32 0, i32 0
+  store %Uint32 %1, %Uint32* %"$$fundef_11_env_a_105"
+  store { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$$fundef_11_cloval_104", { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }* %"$retval_10"
+  %"$$retval_10_106" = load { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }, { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }* %"$retval_10"
+  ret { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$$retval_10_106"
+}
+
+define internal { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } @"$fundef_7"(%"$$fundef_7_env_90"* %0) {
+entry:
+  %"$retval_8" = alloca { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }
+  store { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)* bitcast ({ %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (%"$$fundef_9_env_89"*, %Uint32)* @"$fundef_9" to { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*), i8* null }, { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_8"
+  %"$$retval_8_100" = load { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }, { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_8"
+  ret { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$$retval_8_100"
+}
+
+define internal { i8*, i8* }* @"$fundef_5"(%"$$fundef_5_env_91"* %0) {
+entry:
+  %"$retval_6" = alloca { i8*, i8* }*
+  store { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)* bitcast ({ { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (%"$$fundef_7_env_90"*)* @"$fundef_7" to { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*), i8* null }, { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_95", i32 0, i32 1) to { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_95", i32 0, i32 0), { i8*, i8* }** %"$retval_6"
+  %"$$retval_6_96" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_6"
+  ret { i8*, i8* }* %"$$retval_6_96"
+}
+
+declare i8* @_salloc(i8*, i64)
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* @"$scilla_expr_192"(i8* %0) {
+entry:
+  %"$expr_4" = alloca %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"*
+  %tf = alloca { i8*, i8* }*
+  store { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_5_env_91"*)* @"$fundef_5" to { i8*, i8* }* (i8*)*), i8* null }, { { i8*, i8* }* (i8*)*, i8* }* bitcast ([4 x { i8*, i8* }]* @"$dyndisp_199" to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_13_env_87"*)* @"$fundef_13" to { i8*, i8* }* (i8*)*), i8* null }, { { i8*, i8* }* (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_199", i32 0, i32 2) to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_199", i32 0, i32 0), { i8*, i8* }** %tf
+  %tf1 = alloca { i8*, i8* }*
+  %"$$fundef_21_envp_200_load" = load i8*, i8** @_execptr
+  %"$$fundef_21_envp_200_salloc" = call i8* @_salloc(i8* %"$$fundef_21_envp_200_load", i64 8)
+  %"$$fundef_21_envp_200" = bitcast i8* %"$$fundef_21_envp_200_salloc" to %"$$fundef_21_env_83"*
+  %"$$fundef_21_env_voidp_202" = bitcast %"$$fundef_21_env_83"* %"$$fundef_21_envp_200" to i8*
+  %"$$fundef_21_cloval_203" = insertvalue { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_21_env_83"*)* @"$fundef_21" to { i8*, i8* }* (i8*)*), i8* undef }, i8* %"$$fundef_21_env_voidp_202", 1
+  %"$$fundef_21_env_tf_204" = getelementptr inbounds %"$$fundef_21_env_83", %"$$fundef_21_env_83"* %"$$fundef_21_envp_200", i32 0, i32 0
+  %"$tf_205" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  store { i8*, i8* }* %"$tf_205", { i8*, i8* }** %"$$fundef_21_env_tf_204"
+  %"$$fundef_25_env_voidp_207" = bitcast %"$$fundef_21_env_83"* %"$$fundef_21_envp_200" to i8*
+  %"$$fundef_25_cloval_208" = insertvalue { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_25_env_81"*)* @"$fundef_25" to { i8*, i8* }* (i8*)*), i8* undef }, i8* %"$$fundef_25_env_voidp_207", 1
+  store { { i8*, i8* }* (i8*)*, i8* } %"$$fundef_21_cloval_203", { { i8*, i8* }* (i8*)*, i8* }* bitcast ([4 x { i8*, i8* }]* @"$dyndisp_209" to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { { i8*, i8* }* (i8*)*, i8* } %"$$fundef_25_cloval_208", { { i8*, i8* }* (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_209", i32 0, i32 2) to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_209", i32 0, i32 0), { i8*, i8* }** %tf1
+  %t1 = alloca { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }
+  %"$tf1_210" = load { i8*, i8* }*, { i8*, i8* }** %tf1
+  %"$tf1_211" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf1_210", i32 0
+  %"$tf1_212" = bitcast { i8*, i8* }* %"$tf1_211" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf1_213" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf1_212"
+  %"$tf1_fptr_214" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf1_213", 0
+  %"$tf1_envptr_215" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf1_213", 1
+  %"$tf1_call_216" = call { i8*, i8* }* %"$tf1_fptr_214"(i8* %"$tf1_envptr_215")
+  %"$tf1_217" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf1_call_216", i32 1
+  %"$tf1_218" = bitcast { i8*, i8* }* %"$tf1_217" to { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*
+  %"$tf1_219" = load { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }, { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* %"$tf1_218"
+  %"$tf1_fptr_220" = extractvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf1_219", 0
+  %"$tf1_envptr_221" = extractvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf1_219", 1
+  %"$tf1_call_222" = call { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$tf1_fptr_220"(i8* %"$tf1_envptr_221")
+  store { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$tf1_call_222", { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %t1
+  %t2 = alloca { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }
+  %"$tf1_223" = load { i8*, i8* }*, { i8*, i8* }** %tf1
+  %"$tf1_224" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf1_223", i32 2
+  %"$tf1_225" = bitcast { i8*, i8* }* %"$tf1_224" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf1_226" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf1_225"
+  %"$tf1_fptr_227" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf1_226", 0
+  %"$tf1_envptr_228" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf1_226", 1
+  %"$tf1_call_229" = call { i8*, i8* }* %"$tf1_fptr_227"(i8* %"$tf1_envptr_228")
+  %"$tf1_230" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf1_call_229", i32 3
+  %"$tf1_231" = bitcast { i8*, i8* }* %"$tf1_230" to { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }*
+  %"$tf1_232" = load { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }, { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* }* %"$tf1_231"
+  %"$tf1_fptr_233" = extractvalue { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* } %"$tf1_232", 0
+  %"$tf1_envptr_234" = extractvalue { { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } (i8*)*, i8* } %"$tf1_232", 1
+  %"$tf1_call_235" = call { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } %"$tf1_fptr_233"(i8* %"$tf1_envptr_234")
+  store { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } %"$tf1_call_235", { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }* %t2
+  %uint32_one = alloca %Uint32
+  store %Uint32 { i32 1 }, %Uint32* %uint32_one
+  %uint64_two = alloca %Uint64
+  store %Uint64 { i64 2 }, %Uint64* %uint64_two
+  %hello_string = alloca %String
+  store %String { i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"$stringlit_236", i32 0, i32 0), i32 5 }, %String* %hello_string
+  %addr_bystr20 = alloca [20 x i8]
+  store [20 x i8] c"\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA\AA", [20 x i8]* %addr_bystr20
+  %p1 = alloca %TName_Pair_Uint32_Uint64*
+  %"$t1_0" = alloca { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }
+  %"$t1_237" = load { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }, { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %t1
+  %"$t1_fptr_238" = extractvalue { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$t1_237", 0
+  %"$t1_envptr_239" = extractvalue { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$t1_237", 1
+  %"$uint32_one_240" = load %Uint32, %Uint32* %uint32_one
+  %"$t1_call_241" = call { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$t1_fptr_238"(i8* %"$t1_envptr_239", %Uint32 %"$uint32_one_240")
+  store { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$t1_call_241", { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }* %"$t1_0"
+  %"$t1_1" = alloca %TName_Pair_Uint32_Uint64*
+  %"$$t1_0_242" = load { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }, { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }* %"$t1_0"
+  %"$$t1_0_fptr_243" = extractvalue { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$$t1_0_242", 0
+  %"$$t1_0_envptr_244" = extractvalue { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$$t1_0_242", 1
+  %"$uint64_two_245" = load %Uint64, %Uint64* %uint64_two
+  %"$$t1_0_call_246" = call %TName_Pair_Uint32_Uint64* %"$$t1_0_fptr_243"(i8* %"$$t1_0_envptr_244", %Uint64 %"$uint64_two_245")
+  store %TName_Pair_Uint32_Uint64* %"$$t1_0_call_246", %TName_Pair_Uint32_Uint64** %"$t1_1"
+  %"$$t1_1_247" = load %TName_Pair_Uint32_Uint64*, %TName_Pair_Uint32_Uint64** %"$t1_1"
+  store %TName_Pair_Uint32_Uint64* %"$$t1_1_247", %TName_Pair_Uint32_Uint64** %p1
+  %p2 = alloca %TName_Pair_String_ByStr20*
+  %"$t2_2" = alloca { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* }
+  %"$t2_248" = load { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }, { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* }* %t2
+  %"$t2_fptr_249" = extractvalue { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } %"$t2_248", 0
+  %"$t2_envptr_250" = extractvalue { { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } (i8*, %String)*, i8* } %"$t2_248", 1
+  %"$hello_string_251" = load %String, %String* %hello_string
+  %"$t2_call_252" = call { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } %"$t2_fptr_249"(i8* %"$t2_envptr_250", %String %"$hello_string_251")
+  store { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } %"$t2_call_252", { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* }* %"$t2_2"
+  %"$t2_3" = alloca %TName_Pair_String_ByStr20*
+  %"$$t2_2_253" = load { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* }, { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* }* %"$t2_2"
+  %"$$t2_2_fptr_254" = extractvalue { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } %"$$t2_2_253", 0
+  %"$$t2_2_envptr_255" = extractvalue { %TName_Pair_String_ByStr20* (i8*, [20 x i8]*)*, i8* } %"$$t2_2_253", 1
+  %"$$t2_2_addr_bystr20_256" = alloca [20 x i8]
+  %"$addr_bystr20_257" = load [20 x i8], [20 x i8]* %addr_bystr20
+  store [20 x i8] %"$addr_bystr20_257", [20 x i8]* %"$$t2_2_addr_bystr20_256"
+  %"$$t2_2_call_258" = call %TName_Pair_String_ByStr20* %"$$t2_2_fptr_254"(i8* %"$$t2_2_envptr_255", [20 x i8]* %"$$t2_2_addr_bystr20_256")
+  store %TName_Pair_String_ByStr20* %"$$t2_2_call_258", %TName_Pair_String_ByStr20** %"$t2_3"
+  %"$$t2_3_259" = load %TName_Pair_String_ByStr20*, %TName_Pair_String_ByStr20** %"$t2_3"
+  store %TName_Pair_String_ByStr20* %"$$t2_3_259", %TName_Pair_String_ByStr20** %p2
+  %"$p1_260" = load %TName_Pair_Uint32_Uint64*, %TName_Pair_Uint32_Uint64** %p1
+  %"$p2_261" = load %TName_Pair_String_ByStr20*, %TName_Pair_String_ByStr20** %p2
+  %"$adtval_262_load" = load i8*, i8** @_execptr
+  %"$adtval_262_salloc" = call i8* @_salloc(i8* %"$adtval_262_load", i64 17)
+  %"$adtval_262" = bitcast i8* %"$adtval_262_salloc" to %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"*
+  %"$adtgep_263" = getelementptr inbounds %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)", %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* %"$adtval_262", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_263"
+  %"$adtgep_264" = getelementptr inbounds %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)", %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* %"$adtval_262", i32 0, i32 1
+  store %TName_Pair_Uint32_Uint64* %"$p1_260", %TName_Pair_Uint32_Uint64** %"$adtgep_264"
+  %"$adtgep_265" = getelementptr inbounds %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)", %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* %"$adtval_262", i32 0, i32 2
+  store %TName_Pair_String_ByStr20* %"$p2_261", %TName_Pair_String_ByStr20** %"$adtgep_265"
+  %"$adtptr_266" = bitcast %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* %"$adtval_262" to %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"*
+  store %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* %"$adtptr_266", %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"** %"$expr_4"
+  %"$$expr_4_267" = load %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"*, %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"** %"$expr_4"
+  ret %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* %"$$expr_4_267"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$exprval_268" = call %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* @"$scilla_expr_192"(i8* null)
+  %"$memvoidcast_269" = bitcast %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)"* %"$exprval_268" to i8*
+  call void @_print_scilla_val(%_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_Pair_(Uint32)_(Uint64)_Pair_(String)_(ByStr20)_55", i8* %"$memvoidcast_269")
+  ret void
+}

--- a/tests/codegen/expr/gold/typ3-inst.scilexp.gold
+++ b/tests/codegen/expr/gold/typ3-inst.scilexp.gold
@@ -1,9 +1,426 @@
-Specializing [codegen/expr/typ3-inst.scilexp:2:8] 'A with Uint32
-Specializing [codegen/expr/typ3-inst.scilexp:3:8] 'B with Uint64
-Specializing [codegen/expr/typ3-inst.scilexp:2:8] 'A with ByStr1
-Specializing [codegen/expr/typ3-inst.scilexp:3:8] 'B with Uint64
-Specializing [codegen/expr/typ3-inst.scilexp:3:8] 'B with ByStr2
-Specializing [codegen/expr/typ3-inst.scilexp:10:8] 'A with Uint32
-Specializing [codegen/expr/typ3-inst.scilexp:11:8] 'B with Uint64
+; ModuleID = 'scilla_expr'
+source_filename = "scilla_expr"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
 
-:0:0: error: GenLlvm: genllvm_typ: unsupported type
+%"$TyDescrTy_PrimTyp_31" = type { i32, i32 }
+%_TyDescrTy_Typ = type { i32, i8* }
+%"$TyDescrTy_ADTTyp_57" = type { %TyDescrString, i32, i32, i32, %"$TyDescrTy_ADTTyp_Specl_56"** }
+%TyDescrString = type { i8*, i32 }
+%"$TyDescrTy_ADTTyp_Specl_56" = type { %_TyDescrTy_Typ**, %"$TyDescrTy_ADTTyp_Constr_58"**, %"$TyDescrTy_ADTTyp_57"* }
+%"$TyDescrTy_ADTTyp_Constr_58" = type { %TyDescrString, i32, %_TyDescrTy_Typ** }
+%TName_Pair_Uint32_Uint64 = type { i8, %CName_Pair_Uint32_Uint64* }
+%CName_Pair_Uint32_Uint64 = type <{ i8, %Uint32, %Uint64 }>
+%Uint64 = type { i64 }
+%Uint32 = type { i32 }
+%"$$fundef_29_env_91" = type { { i8*, i8* }* }
+%"$$fundef_27_env_92" = type { { i8*, i8* }* }
+%TName_Pair_ByStr1_ByStr2 = type { i8, %CName_Pair_ByStr1_ByStr2* }
+%CName_Pair_ByStr1_ByStr2 = type <{ i8, [1 x i8], [2 x i8] }>
+%"$$fundef_25_env_93" = type { [1 x i8] }
+%"$$fundef_23_env_94" = type {}
+%"$$fundef_21_env_95" = type {}
+%TName_Pair_ByStr1_Uint64 = type { i8, %CName_Pair_ByStr1_Uint64* }
+%CName_Pair_ByStr1_Uint64 = type <{ i8, [1 x i8], %Uint64 }>
+%"$$fundef_19_env_96" = type { [1 x i8] }
+%"$$fundef_17_env_97" = type {}
+%"$$fundef_15_env_98" = type {}
+%"$$fundef_13_env_99" = type {}
+%"$$fundef_11_env_100" = type { %Uint32 }
+%"$$fundef_9_env_101" = type {}
+%"$$fundef_7_env_102" = type {}
+%"$$fundef_5_env_103" = type {}
+%"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)" = type { i8, %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* }
+%"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)" = type <{ i8, %TName_Pair_Uint32_Uint64*, %TName_Pair_ByStr1_ByStr2* }>
+
+@_execptr = global i8* null
+@"$TyDescr_Int32_Prim_32" = global %"$TyDescrTy_PrimTyp_31" zeroinitializer
+@"$TyDescr_Int32_33" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Int32_Prim_32" to i8*) }
+@"$TyDescr_Uint32_Prim_34" = global %"$TyDescrTy_PrimTyp_31" { i32 1, i32 0 }
+@"$TyDescr_Uint32_35" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Uint32_Prim_34" to i8*) }
+@"$TyDescr_Int64_Prim_36" = global %"$TyDescrTy_PrimTyp_31" { i32 0, i32 1 }
+@"$TyDescr_Int64_37" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Int64_Prim_36" to i8*) }
+@"$TyDescr_Uint64_Prim_38" = global %"$TyDescrTy_PrimTyp_31" { i32 1, i32 1 }
+@"$TyDescr_Uint64_39" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Uint64_Prim_38" to i8*) }
+@"$TyDescr_Int128_Prim_40" = global %"$TyDescrTy_PrimTyp_31" { i32 0, i32 2 }
+@"$TyDescr_Int128_41" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Int128_Prim_40" to i8*) }
+@"$TyDescr_Uint128_Prim_42" = global %"$TyDescrTy_PrimTyp_31" { i32 1, i32 2 }
+@"$TyDescr_Uint128_43" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Uint128_Prim_42" to i8*) }
+@"$TyDescr_Int256_Prim_44" = global %"$TyDescrTy_PrimTyp_31" { i32 0, i32 3 }
+@"$TyDescr_Int256_45" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Int256_Prim_44" to i8*) }
+@"$TyDescr_Uint256_Prim_46" = global %"$TyDescrTy_PrimTyp_31" { i32 1, i32 3 }
+@"$TyDescr_Uint256_47" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Uint256_Prim_46" to i8*) }
+@"$TyDescr_String_Prim_48" = global %"$TyDescrTy_PrimTyp_31" { i32 2, i32 0 }
+@"$TyDescr_String_49" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_String_Prim_48" to i8*) }
+@"$TyDescr_Bystr_Prim_50" = global %"$TyDescrTy_PrimTyp_31" { i32 7, i32 0 }
+@"$TyDescr_Bystr_51" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Bystr_Prim_50" to i8*) }
+@"$TyDescr_Bystr2_Prim_52" = global %"$TyDescrTy_PrimTyp_31" { i32 8, i32 2 }
+@"$TyDescr_Bystr2_53" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Bystr2_Prim_52" to i8*) }
+@"$TyDescr_Bystr1_Prim_54" = global %"$TyDescrTy_PrimTyp_31" { i32 8, i32 1 }
+@"$TyDescr_Bystr1_55" = global %_TyDescrTy_Typ { i32 0, i8* bitcast (%"$TyDescrTy_PrimTyp_31"* @"$TyDescr_Bystr1_Prim_54" to i8*) }
+@"$TyDescr_ADT_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_59" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_56"* @"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Specl_70" to i8*) }
+@"$TyDescr_ADT_Pair_ByStr1_ByStr2_60" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_56"* @"$TyDescr_Pair_ByStr1_ByStr2_ADTTyp_Specl_76" to i8*) }
+@"$TyDescr_ADT_Pair_ByStr1_Uint64_61" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_56"* @"$TyDescr_Pair_ByStr1_Uint64_ADTTyp_Specl_82" to i8*) }
+@"$TyDescr_ADT_Pair_Uint32_Uint64_62" = unnamed_addr constant %_TyDescrTy_Typ { i32 1, i8* bitcast (%"$TyDescrTy_ADTTyp_Specl_56"* @"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_88" to i8*) }
+@"$TyDescr_Pair_ADTTyp_64" = unnamed_addr constant %"$TyDescrTy_ADTTyp_57" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_90", i32 0, i32 0), i32 4 }, i32 2, i32 1, i32 4, %"$TyDescrTy_ADTTyp_Specl_56"** getelementptr inbounds ([4 x %"$TyDescrTy_ADTTyp_Specl_56"*], [4 x %"$TyDescrTy_ADTTyp_Specl_56"*]* @"$TyDescr_Pair_ADTTyp_m_specls_89", i32 0, i32 0) }
+@"$TyDescr_Pair_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_Constr_m_args_65" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_Uint32_Uint64_62", %_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_ByStr1_ByStr2_60"]
+@"$TyDescr_ADT_Pair_66" = unnamed_addr constant [4 x i8] c"Pair"
+@"$TyDescr_Pair_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Constr_67" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_58" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_66", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_Constr_m_args_65", i32 0, i32 0) }
+@"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Specl_m_constrs_68" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Constr_58"*] [%"$TyDescrTy_ADTTyp_Constr_58"* @"$TyDescr_Pair_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Constr_67"]
+@"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Specl_m_TArgs_69" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_Uint32_Uint64_62", %_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_ByStr1_ByStr2_60"]
+@"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Specl_70" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_56" { %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Specl_m_TArgs_69", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_58"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Constr_58"*], [1 x %"$TyDescrTy_ADTTyp_Constr_58"*]* @"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Specl_m_constrs_68", i32 0, i32 0), %"$TyDescrTy_ADTTyp_57"* @"$TyDescr_Pair_ADTTyp_64" }
+@"$TyDescr_Pair_Pair_ByStr1_ByStr2_Constr_m_args_71" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Bystr1_55", %_TyDescrTy_Typ* @"$TyDescr_Bystr2_53"]
+@"$TyDescr_ADT_Pair_72" = unnamed_addr constant [4 x i8] c"Pair"
+@"$TyDescr_Pair_Pair_ByStr1_ByStr2_ADTTyp_Constr_73" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_58" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_72", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_ByStr1_ByStr2_Constr_m_args_71", i32 0, i32 0) }
+@"$TyDescr_Pair_ByStr1_ByStr2_ADTTyp_Specl_m_constrs_74" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Constr_58"*] [%"$TyDescrTy_ADTTyp_Constr_58"* @"$TyDescr_Pair_Pair_ByStr1_ByStr2_ADTTyp_Constr_73"]
+@"$TyDescr_Pair_ByStr1_ByStr2_ADTTyp_Specl_m_TArgs_75" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Bystr1_55", %_TyDescrTy_Typ* @"$TyDescr_Bystr2_53"]
+@"$TyDescr_Pair_ByStr1_ByStr2_ADTTyp_Specl_76" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_56" { %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_ByStr1_ByStr2_ADTTyp_Specl_m_TArgs_75", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_58"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Constr_58"*], [1 x %"$TyDescrTy_ADTTyp_Constr_58"*]* @"$TyDescr_Pair_ByStr1_ByStr2_ADTTyp_Specl_m_constrs_74", i32 0, i32 0), %"$TyDescrTy_ADTTyp_57"* @"$TyDescr_Pair_ADTTyp_64" }
+@"$TyDescr_Pair_Pair_ByStr1_Uint64_Constr_m_args_77" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Bystr1_55", %_TyDescrTy_Typ* @"$TyDescr_Uint64_39"]
+@"$TyDescr_ADT_Pair_78" = unnamed_addr constant [4 x i8] c"Pair"
+@"$TyDescr_Pair_Pair_ByStr1_Uint64_ADTTyp_Constr_79" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_58" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_78", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_ByStr1_Uint64_Constr_m_args_77", i32 0, i32 0) }
+@"$TyDescr_Pair_ByStr1_Uint64_ADTTyp_Specl_m_constrs_80" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Constr_58"*] [%"$TyDescrTy_ADTTyp_Constr_58"* @"$TyDescr_Pair_Pair_ByStr1_Uint64_ADTTyp_Constr_79"]
+@"$TyDescr_Pair_ByStr1_Uint64_ADTTyp_Specl_m_TArgs_81" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Bystr1_55", %_TyDescrTy_Typ* @"$TyDescr_Uint64_39"]
+@"$TyDescr_Pair_ByStr1_Uint64_ADTTyp_Specl_82" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_56" { %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_ByStr1_Uint64_ADTTyp_Specl_m_TArgs_81", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_58"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Constr_58"*], [1 x %"$TyDescrTy_ADTTyp_Constr_58"*]* @"$TyDescr_Pair_ByStr1_Uint64_ADTTyp_Specl_m_constrs_80", i32 0, i32 0), %"$TyDescrTy_ADTTyp_57"* @"$TyDescr_Pair_ADTTyp_64" }
+@"$TyDescr_Pair_Pair_Uint32_Uint64_Constr_m_args_83" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Uint32_35", %_TyDescrTy_Typ* @"$TyDescr_Uint64_39"]
+@"$TyDescr_ADT_Pair_84" = unnamed_addr constant [4 x i8] c"Pair"
+@"$TyDescr_Pair_Pair_Uint32_Uint64_ADTTyp_Constr_85" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Constr_58" { %TyDescrString { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"$TyDescr_ADT_Pair_84", i32 0, i32 0), i32 4 }, i32 2, %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Pair_Uint32_Uint64_Constr_m_args_83", i32 0, i32 0) }
+@"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_m_constrs_86" = unnamed_addr constant [1 x %"$TyDescrTy_ADTTyp_Constr_58"*] [%"$TyDescrTy_ADTTyp_Constr_58"* @"$TyDescr_Pair_Pair_Uint32_Uint64_ADTTyp_Constr_85"]
+@"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_m_TArgs_87" = unnamed_addr constant [2 x %_TyDescrTy_Typ*] [%_TyDescrTy_Typ* @"$TyDescr_Uint32_35", %_TyDescrTy_Typ* @"$TyDescr_Uint64_39"]
+@"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_88" = unnamed_addr constant %"$TyDescrTy_ADTTyp_Specl_56" { %_TyDescrTy_Typ** getelementptr inbounds ([2 x %_TyDescrTy_Typ*], [2 x %_TyDescrTy_Typ*]* @"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_m_TArgs_87", i32 0, i32 0), %"$TyDescrTy_ADTTyp_Constr_58"** getelementptr inbounds ([1 x %"$TyDescrTy_ADTTyp_Constr_58"*], [1 x %"$TyDescrTy_ADTTyp_Constr_58"*]* @"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_m_constrs_86", i32 0, i32 0), %"$TyDescrTy_ADTTyp_57"* @"$TyDescr_Pair_ADTTyp_64" }
+@"$TyDescr_Pair_ADTTyp_m_specls_89" = unnamed_addr constant [4 x %"$TyDescrTy_ADTTyp_Specl_56"*] [%"$TyDescrTy_ADTTyp_Specl_56"* @"$TyDescr_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_ADTTyp_Specl_70", %"$TyDescrTy_ADTTyp_Specl_56"* @"$TyDescr_Pair_ByStr1_ByStr2_ADTTyp_Specl_76", %"$TyDescrTy_ADTTyp_Specl_56"* @"$TyDescr_Pair_ByStr1_Uint64_ADTTyp_Specl_82", %"$TyDescrTy_ADTTyp_Specl_56"* @"$TyDescr_Pair_Uint32_Uint64_ADTTyp_Specl_88"]
+@"$TyDescr_ADT_Pair_90" = unnamed_addr constant [4 x i8] c"Pair"
+@"$dyndisp_107" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_134" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_182" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_207" = global [4 x { i8*, i8* }] zeroinitializer
+@"$dyndisp_214" = global [4 x { i8*, i8* }] zeroinitializer
+
+define internal { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } @"$fundef_29"(%"$$fundef_29_env_91"* %0) {
+entry:
+  %"$$fundef_29_env_tf_184" = getelementptr inbounds %"$$fundef_29_env_91", %"$$fundef_29_env_91"* %0, i32 0, i32 0
+  %"$tf_envload_185" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_29_env_tf_184"
+  %tf = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$tf_envload_185", { i8*, i8* }** %tf
+  %"$retval_30" = alloca { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }
+  %"$tf_186" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  %"$tf_187" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_186", i32 0
+  %"$tf_188" = bitcast { i8*, i8* }* %"$tf_187" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf_189" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf_188"
+  %"$tf_fptr_190" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_189", 0
+  %"$tf_envptr_191" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_189", 1
+  %"$tf_call_192" = call { i8*, i8* }* %"$tf_fptr_190"(i8* %"$tf_envptr_191")
+  %"$tf_193" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_call_192", i32 1
+  %"$tf_194" = bitcast { i8*, i8* }* %"$tf_193" to { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*
+  %"$tf_195" = load { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }, { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* %"$tf_194"
+  %"$tf_fptr_196" = extractvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf_195", 0
+  %"$tf_envptr_197" = extractvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf_195", 1
+  %"$tf_call_198" = call { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$tf_fptr_196"(i8* %"$tf_envptr_197")
+  store { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$tf_call_198", { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_30"
+  %"$$retval_30_199" = load { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }, { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_30"
+  ret { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$$retval_30_199"
+}
+
+define internal { i8*, i8* }* @"$fundef_27"(%"$$fundef_27_env_92"* %0) {
+entry:
+  %"$$fundef_27_env_tf_174" = getelementptr inbounds %"$$fundef_27_env_92", %"$$fundef_27_env_92"* %0, i32 0, i32 0
+  %"$tf_envload_175" = load { i8*, i8* }*, { i8*, i8* }** %"$$fundef_27_env_tf_174"
+  %tf = alloca { i8*, i8* }*
+  store { i8*, i8* }* %"$tf_envload_175", { i8*, i8* }** %tf
+  %"$retval_28" = alloca { i8*, i8* }*
+  %"$$fundef_29_envp_176_load" = load i8*, i8** @_execptr
+  %"$$fundef_29_envp_176_salloc" = call i8* @_salloc(i8* %"$$fundef_29_envp_176_load", i64 8)
+  %"$$fundef_29_envp_176" = bitcast i8* %"$$fundef_29_envp_176_salloc" to %"$$fundef_29_env_91"*
+  %"$$fundef_29_env_voidp_178" = bitcast %"$$fundef_29_env_91"* %"$$fundef_29_envp_176" to i8*
+  %"$$fundef_29_cloval_179" = insertvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)* bitcast ({ { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (%"$$fundef_29_env_91"*)* @"$fundef_29" to { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*), i8* undef }, i8* %"$$fundef_29_env_voidp_178", 1
+  %"$$fundef_29_env_tf_180" = getelementptr inbounds %"$$fundef_29_env_91", %"$$fundef_29_env_91"* %"$$fundef_29_envp_176", i32 0, i32 0
+  %"$tf_181" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  store { i8*, i8* }* %"$tf_181", { i8*, i8* }** %"$$fundef_29_env_tf_180"
+  store { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$$fundef_29_cloval_179", { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_182", i32 0, i32 1) to { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_182", i32 0, i32 0), { i8*, i8* }** %"$retval_28"
+  %"$$retval_28_183" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_28"
+  ret { i8*, i8* }* %"$$retval_28_183"
+}
+
+define internal %TName_Pair_ByStr1_ByStr2* @"$fundef_25"(%"$$fundef_25_env_93"* %0, [2 x i8] %1) {
+entry:
+  %"$$fundef_25_env_a_165" = getelementptr inbounds %"$$fundef_25_env_93", %"$$fundef_25_env_93"* %0, i32 0, i32 0
+  %"$a_envload_166" = load [1 x i8], [1 x i8]* %"$$fundef_25_env_a_165"
+  %a = alloca [1 x i8]
+  store [1 x i8] %"$a_envload_166", [1 x i8]* %a
+  %"$retval_26" = alloca %TName_Pair_ByStr1_ByStr2*
+  %"$a_167" = load [1 x i8], [1 x i8]* %a
+  %"$adtval_168_load" = load i8*, i8** @_execptr
+  %"$adtval_168_salloc" = call i8* @_salloc(i8* %"$adtval_168_load", i64 4)
+  %"$adtval_168" = bitcast i8* %"$adtval_168_salloc" to %CName_Pair_ByStr1_ByStr2*
+  %"$adtgep_169" = getelementptr inbounds %CName_Pair_ByStr1_ByStr2, %CName_Pair_ByStr1_ByStr2* %"$adtval_168", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_169"
+  %"$adtgep_170" = getelementptr inbounds %CName_Pair_ByStr1_ByStr2, %CName_Pair_ByStr1_ByStr2* %"$adtval_168", i32 0, i32 1
+  store [1 x i8] %"$a_167", [1 x i8]* %"$adtgep_170"
+  %"$adtgep_171" = getelementptr inbounds %CName_Pair_ByStr1_ByStr2, %CName_Pair_ByStr1_ByStr2* %"$adtval_168", i32 0, i32 2
+  store [2 x i8] %1, [2 x i8]* %"$adtgep_171"
+  %"$adtptr_172" = bitcast %CName_Pair_ByStr1_ByStr2* %"$adtval_168" to %TName_Pair_ByStr1_ByStr2*
+  store %TName_Pair_ByStr1_ByStr2* %"$adtptr_172", %TName_Pair_ByStr1_ByStr2** %"$retval_26"
+  %"$$retval_26_173" = load %TName_Pair_ByStr1_ByStr2*, %TName_Pair_ByStr1_ByStr2** %"$retval_26"
+  ret %TName_Pair_ByStr1_ByStr2* %"$$retval_26_173"
+}
+
+define internal { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } @"$fundef_23"(%"$$fundef_23_env_94"* %0, [1 x i8] %1) {
+entry:
+  %"$retval_24" = alloca { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* }
+  %"$$fundef_25_envp_159_load" = load i8*, i8** @_execptr
+  %"$$fundef_25_envp_159_salloc" = call i8* @_salloc(i8* %"$$fundef_25_envp_159_load", i64 1)
+  %"$$fundef_25_envp_159" = bitcast i8* %"$$fundef_25_envp_159_salloc" to %"$$fundef_25_env_93"*
+  %"$$fundef_25_env_voidp_161" = bitcast %"$$fundef_25_env_93"* %"$$fundef_25_envp_159" to i8*
+  %"$$fundef_25_cloval_162" = insertvalue { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])* bitcast (%TName_Pair_ByStr1_ByStr2* (%"$$fundef_25_env_93"*, [2 x i8])* @"$fundef_25" to %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*), i8* undef }, i8* %"$$fundef_25_env_voidp_161", 1
+  %"$$fundef_25_env_a_163" = getelementptr inbounds %"$$fundef_25_env_93", %"$$fundef_25_env_93"* %"$$fundef_25_envp_159", i32 0, i32 0
+  store [1 x i8] %1, [1 x i8]* %"$$fundef_25_env_a_163"
+  store { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } %"$$fundef_25_cloval_162", { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* }* %"$retval_24"
+  %"$$retval_24_164" = load { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* }, { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* }* %"$retval_24"
+  ret { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } %"$$retval_24_164"
+}
+
+define internal { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } @"$fundef_21"(%"$$fundef_21_env_95"* %0) {
+entry:
+  %"$retval_22" = alloca { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* }
+  store { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])* bitcast ({ %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (%"$$fundef_23_env_94"*, [1 x i8])* @"$fundef_23" to { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*), i8* null }, { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* }* %"$retval_22"
+  %"$$retval_22_158" = load { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* }, { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* }* %"$retval_22"
+  ret { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } %"$$retval_22_158"
+}
+
+define internal %TName_Pair_ByStr1_Uint64* @"$fundef_19"(%"$$fundef_19_env_96"* %0, %Uint64 %1) {
+entry:
+  %"$$fundef_19_env_a_146" = getelementptr inbounds %"$$fundef_19_env_96", %"$$fundef_19_env_96"* %0, i32 0, i32 0
+  %"$a_envload_147" = load [1 x i8], [1 x i8]* %"$$fundef_19_env_a_146"
+  %a = alloca [1 x i8]
+  store [1 x i8] %"$a_envload_147", [1 x i8]* %a
+  %"$retval_20" = alloca %TName_Pair_ByStr1_Uint64*
+  %"$a_148" = load [1 x i8], [1 x i8]* %a
+  %"$adtval_149_load" = load i8*, i8** @_execptr
+  %"$adtval_149_salloc" = call i8* @_salloc(i8* %"$adtval_149_load", i64 10)
+  %"$adtval_149" = bitcast i8* %"$adtval_149_salloc" to %CName_Pair_ByStr1_Uint64*
+  %"$adtgep_150" = getelementptr inbounds %CName_Pair_ByStr1_Uint64, %CName_Pair_ByStr1_Uint64* %"$adtval_149", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_150"
+  %"$adtgep_151" = getelementptr inbounds %CName_Pair_ByStr1_Uint64, %CName_Pair_ByStr1_Uint64* %"$adtval_149", i32 0, i32 1
+  store [1 x i8] %"$a_148", [1 x i8]* %"$adtgep_151"
+  %"$adtgep_152" = getelementptr inbounds %CName_Pair_ByStr1_Uint64, %CName_Pair_ByStr1_Uint64* %"$adtval_149", i32 0, i32 2
+  store %Uint64 %1, %Uint64* %"$adtgep_152"
+  %"$adtptr_153" = bitcast %CName_Pair_ByStr1_Uint64* %"$adtval_149" to %TName_Pair_ByStr1_Uint64*
+  store %TName_Pair_ByStr1_Uint64* %"$adtptr_153", %TName_Pair_ByStr1_Uint64** %"$retval_20"
+  %"$$retval_20_154" = load %TName_Pair_ByStr1_Uint64*, %TName_Pair_ByStr1_Uint64** %"$retval_20"
+  ret %TName_Pair_ByStr1_Uint64* %"$$retval_20_154"
+}
+
+define internal { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } @"$fundef_17"(%"$$fundef_17_env_97"* %0, [1 x i8] %1) {
+entry:
+  %"$retval_18" = alloca { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* }
+  %"$$fundef_19_envp_140_load" = load i8*, i8** @_execptr
+  %"$$fundef_19_envp_140_salloc" = call i8* @_salloc(i8* %"$$fundef_19_envp_140_load", i64 1)
+  %"$$fundef_19_envp_140" = bitcast i8* %"$$fundef_19_envp_140_salloc" to %"$$fundef_19_env_96"*
+  %"$$fundef_19_env_voidp_142" = bitcast %"$$fundef_19_env_96"* %"$$fundef_19_envp_140" to i8*
+  %"$$fundef_19_cloval_143" = insertvalue { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)* bitcast (%TName_Pair_ByStr1_Uint64* (%"$$fundef_19_env_96"*, %Uint64)* @"$fundef_19" to %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*), i8* undef }, i8* %"$$fundef_19_env_voidp_142", 1
+  %"$$fundef_19_env_a_144" = getelementptr inbounds %"$$fundef_19_env_96", %"$$fundef_19_env_96"* %"$$fundef_19_envp_140", i32 0, i32 0
+  store [1 x i8] %1, [1 x i8]* %"$$fundef_19_env_a_144"
+  store { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } %"$$fundef_19_cloval_143", { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* }* %"$retval_18"
+  %"$$retval_18_145" = load { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* }, { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* }* %"$retval_18"
+  ret { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } %"$$retval_18_145"
+}
+
+define internal { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } @"$fundef_15"(%"$$fundef_15_env_98"* %0) {
+entry:
+  %"$retval_16" = alloca { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* }
+  store { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])* bitcast ({ %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (%"$$fundef_17_env_97"*, [1 x i8])* @"$fundef_17" to { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*), i8* null }, { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* }* %"$retval_16"
+  %"$$retval_16_139" = load { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* }, { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* }* %"$retval_16"
+  ret { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } %"$$retval_16_139"
+}
+
+define internal { i8*, i8* }* @"$fundef_13"(%"$$fundef_13_env_99"* %0) {
+entry:
+  %"$retval_14" = alloca { i8*, i8* }*
+  store { { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* } { { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } (i8*)* bitcast ({ { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } (%"$$fundef_15_env_98"*)* @"$fundef_15" to { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*), i8* null }, { { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_134", i32 0, i32 1) to { { { %TName_Pair_ByStr1_Uint64* (i8*, %Uint64)*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* }*)
+  store { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* } { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)* bitcast ({ { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (%"$$fundef_21_env_95"*)* @"$fundef_21" to { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*), i8* null }, { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_134", i32 0, i32 3) to { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_134", i32 0, i32 0), { i8*, i8* }** %"$retval_14"
+  %"$$retval_14_135" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_14"
+  ret { i8*, i8* }* %"$$retval_14_135"
+}
+
+define internal %TName_Pair_Uint32_Uint64* @"$fundef_11"(%"$$fundef_11_env_100"* %0, %Uint64 %1) {
+entry:
+  %"$$fundef_11_env_a_119" = getelementptr inbounds %"$$fundef_11_env_100", %"$$fundef_11_env_100"* %0, i32 0, i32 0
+  %"$a_envload_120" = load %Uint32, %Uint32* %"$$fundef_11_env_a_119"
+  %a = alloca %Uint32
+  store %Uint32 %"$a_envload_120", %Uint32* %a
+  %"$retval_12" = alloca %TName_Pair_Uint32_Uint64*
+  %"$a_121" = load %Uint32, %Uint32* %a
+  %"$adtval_122_load" = load i8*, i8** @_execptr
+  %"$adtval_122_salloc" = call i8* @_salloc(i8* %"$adtval_122_load", i64 13)
+  %"$adtval_122" = bitcast i8* %"$adtval_122_salloc" to %CName_Pair_Uint32_Uint64*
+  %"$adtgep_123" = getelementptr inbounds %CName_Pair_Uint32_Uint64, %CName_Pair_Uint32_Uint64* %"$adtval_122", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_123"
+  %"$adtgep_124" = getelementptr inbounds %CName_Pair_Uint32_Uint64, %CName_Pair_Uint32_Uint64* %"$adtval_122", i32 0, i32 1
+  store %Uint32 %"$a_121", %Uint32* %"$adtgep_124"
+  %"$adtgep_125" = getelementptr inbounds %CName_Pair_Uint32_Uint64, %CName_Pair_Uint32_Uint64* %"$adtval_122", i32 0, i32 2
+  store %Uint64 %1, %Uint64* %"$adtgep_125"
+  %"$adtptr_126" = bitcast %CName_Pair_Uint32_Uint64* %"$adtval_122" to %TName_Pair_Uint32_Uint64*
+  store %TName_Pair_Uint32_Uint64* %"$adtptr_126", %TName_Pair_Uint32_Uint64** %"$retval_12"
+  %"$$retval_12_127" = load %TName_Pair_Uint32_Uint64*, %TName_Pair_Uint32_Uint64** %"$retval_12"
+  ret %TName_Pair_Uint32_Uint64* %"$$retval_12_127"
+}
+
+define internal { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } @"$fundef_9"(%"$$fundef_9_env_101"* %0, %Uint32 %1) {
+entry:
+  %"$retval_10" = alloca { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }
+  %"$$fundef_11_envp_113_load" = load i8*, i8** @_execptr
+  %"$$fundef_11_envp_113_salloc" = call i8* @_salloc(i8* %"$$fundef_11_envp_113_load", i64 4)
+  %"$$fundef_11_envp_113" = bitcast i8* %"$$fundef_11_envp_113_salloc" to %"$$fundef_11_env_100"*
+  %"$$fundef_11_env_voidp_115" = bitcast %"$$fundef_11_env_100"* %"$$fundef_11_envp_113" to i8*
+  %"$$fundef_11_cloval_116" = insertvalue { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)* bitcast (%TName_Pair_Uint32_Uint64* (%"$$fundef_11_env_100"*, %Uint64)* @"$fundef_11" to %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*), i8* undef }, i8* %"$$fundef_11_env_voidp_115", 1
+  %"$$fundef_11_env_a_117" = getelementptr inbounds %"$$fundef_11_env_100", %"$$fundef_11_env_100"* %"$$fundef_11_envp_113", i32 0, i32 0
+  store %Uint32 %1, %Uint32* %"$$fundef_11_env_a_117"
+  store { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$$fundef_11_cloval_116", { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }* %"$retval_10"
+  %"$$retval_10_118" = load { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }, { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }* %"$retval_10"
+  ret { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$$retval_10_118"
+}
+
+define internal { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } @"$fundef_7"(%"$$fundef_7_env_102"* %0) {
+entry:
+  %"$retval_8" = alloca { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }
+  store { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)* bitcast ({ %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (%"$$fundef_9_env_101"*, %Uint32)* @"$fundef_9" to { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*), i8* null }, { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_8"
+  %"$$retval_8_112" = load { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }, { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %"$retval_8"
+  ret { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$$retval_8_112"
+}
+
+define internal { i8*, i8* }* @"$fundef_5"(%"$$fundef_5_env_103"* %0) {
+entry:
+  %"$retval_6" = alloca { i8*, i8* }*
+  store { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)* bitcast ({ { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (%"$$fundef_7_env_102"*)* @"$fundef_7" to { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*), i8* null }, { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_107", i32 0, i32 1) to { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_107", i32 0, i32 0), { i8*, i8* }** %"$retval_6"
+  %"$$retval_6_108" = load { i8*, i8* }*, { i8*, i8* }** %"$retval_6"
+  ret { i8*, i8* }* %"$$retval_6_108"
+}
+
+declare i8* @_salloc(i8*, i64)
+
+define void @_init_libs() {
+entry:
+  ret void
+}
+
+define internal %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* @"$scilla_expr_200"(i8* %0) {
+entry:
+  %"$expr_4" = alloca %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"*
+  %tf = alloca { i8*, i8* }*
+  store { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_5_env_103"*)* @"$fundef_5" to { i8*, i8* }* (i8*)*), i8* null }, { { i8*, i8* }* (i8*)*, i8* }* bitcast ([4 x { i8*, i8* }]* @"$dyndisp_207" to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_13_env_99"*)* @"$fundef_13" to { i8*, i8* }* (i8*)*), i8* null }, { { i8*, i8* }* (i8*)*, i8* }* bitcast ({ i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_207", i32 0, i32 2) to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_207", i32 0, i32 0), { i8*, i8* }** %tf
+  %tf1 = alloca { i8*, i8* }*
+  %"$$fundef_27_envp_208_load" = load i8*, i8** @_execptr
+  %"$$fundef_27_envp_208_salloc" = call i8* @_salloc(i8* %"$$fundef_27_envp_208_load", i64 8)
+  %"$$fundef_27_envp_208" = bitcast i8* %"$$fundef_27_envp_208_salloc" to %"$$fundef_27_env_92"*
+  %"$$fundef_27_env_voidp_210" = bitcast %"$$fundef_27_env_92"* %"$$fundef_27_envp_208" to i8*
+  %"$$fundef_27_cloval_211" = insertvalue { { i8*, i8* }* (i8*)*, i8* } { { i8*, i8* }* (i8*)* bitcast ({ i8*, i8* }* (%"$$fundef_27_env_92"*)* @"$fundef_27" to { i8*, i8* }* (i8*)*), i8* undef }, i8* %"$$fundef_27_env_voidp_210", 1
+  %"$$fundef_27_env_tf_212" = getelementptr inbounds %"$$fundef_27_env_92", %"$$fundef_27_env_92"* %"$$fundef_27_envp_208", i32 0, i32 0
+  %"$tf_213" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  store { i8*, i8* }* %"$tf_213", { i8*, i8* }** %"$$fundef_27_env_tf_212"
+  store { { i8*, i8* }* (i8*)*, i8* } %"$$fundef_27_cloval_211", { { i8*, i8* }* (i8*)*, i8* }* bitcast ([4 x { i8*, i8* }]* @"$dyndisp_214" to { { i8*, i8* }* (i8*)*, i8* }*)
+  store { i8*, i8* }* getelementptr inbounds ([4 x { i8*, i8* }], [4 x { i8*, i8* }]* @"$dyndisp_214", i32 0, i32 0), { i8*, i8* }** %tf1
+  %t1 = alloca { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }
+  %"$tf1_215" = load { i8*, i8* }*, { i8*, i8* }** %tf1
+  %"$tf1_216" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf1_215", i32 0
+  %"$tf1_217" = bitcast { i8*, i8* }* %"$tf1_216" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf1_218" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf1_217"
+  %"$tf1_fptr_219" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf1_218", 0
+  %"$tf1_envptr_220" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf1_218", 1
+  %"$tf1_call_221" = call { i8*, i8* }* %"$tf1_fptr_219"(i8* %"$tf1_envptr_220")
+  %"$tf1_222" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf1_call_221", i32 1
+  %"$tf1_223" = bitcast { i8*, i8* }* %"$tf1_222" to { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }*
+  %"$tf1_224" = load { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }, { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* }* %"$tf1_223"
+  %"$tf1_fptr_225" = extractvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf1_224", 0
+  %"$tf1_envptr_226" = extractvalue { { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } (i8*)*, i8* } %"$tf1_224", 1
+  %"$tf1_call_227" = call { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$tf1_fptr_225"(i8* %"$tf1_envptr_226")
+  store { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$tf1_call_227", { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %t1
+  %t3 = alloca { i8*, i8* }*
+  %"$tf_228" = load { i8*, i8* }*, { i8*, i8* }** %tf
+  %"$tf_229" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$tf_228", i32 2
+  %"$tf_230" = bitcast { i8*, i8* }* %"$tf_229" to { { i8*, i8* }* (i8*)*, i8* }*
+  %"$tf_231" = load { { i8*, i8* }* (i8*)*, i8* }, { { i8*, i8* }* (i8*)*, i8* }* %"$tf_230"
+  %"$tf_fptr_232" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_231", 0
+  %"$tf_envptr_233" = extractvalue { { i8*, i8* }* (i8*)*, i8* } %"$tf_231", 1
+  %"$tf_call_234" = call { i8*, i8* }* %"$tf_fptr_232"(i8* %"$tf_envptr_233")
+  store { i8*, i8* }* %"$tf_call_234", { i8*, i8* }** %t3
+  %t4 = alloca { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* }
+  %"$t3_235" = load { i8*, i8* }*, { i8*, i8* }** %t3
+  %"$t3_236" = getelementptr { i8*, i8* }, { i8*, i8* }* %"$t3_235", i32 3
+  %"$t3_237" = bitcast { i8*, i8* }* %"$t3_236" to { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* }*
+  %"$t3_238" = load { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* }, { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* }* %"$t3_237"
+  %"$t3_fptr_239" = extractvalue { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* } %"$t3_238", 0
+  %"$t3_envptr_240" = extractvalue { { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } (i8*)*, i8* } %"$t3_238", 1
+  %"$t3_call_241" = call { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } %"$t3_fptr_239"(i8* %"$t3_envptr_240")
+  store { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } %"$t3_call_241", { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* }* %t4
+  %uint32_one = alloca %Uint32
+  store %Uint32 { i32 1 }, %Uint32* %uint32_one
+  %uint64_two = alloca %Uint64
+  store %Uint64 { i64 2 }, %Uint64* %uint64_two
+  %addr_bystr1 = alloca [1 x i8]
+  store [1 x i8] c"\AA", [1 x i8]* %addr_bystr1
+  %addr_bystr2 = alloca [2 x i8]
+  store [2 x i8] c"\AA\BB", [2 x i8]* %addr_bystr2
+  %p1 = alloca %TName_Pair_Uint32_Uint64*
+  %"$t1_0" = alloca { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }
+  %"$t1_242" = load { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }, { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* }* %t1
+  %"$t1_fptr_243" = extractvalue { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$t1_242", 0
+  %"$t1_envptr_244" = extractvalue { { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } (i8*, %Uint32)*, i8* } %"$t1_242", 1
+  %"$uint32_one_245" = load %Uint32, %Uint32* %uint32_one
+  %"$t1_call_246" = call { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$t1_fptr_243"(i8* %"$t1_envptr_244", %Uint32 %"$uint32_one_245")
+  store { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$t1_call_246", { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }* %"$t1_0"
+  %"$t1_1" = alloca %TName_Pair_Uint32_Uint64*
+  %"$$t1_0_247" = load { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }, { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* }* %"$t1_0"
+  %"$$t1_0_fptr_248" = extractvalue { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$$t1_0_247", 0
+  %"$$t1_0_envptr_249" = extractvalue { %TName_Pair_Uint32_Uint64* (i8*, %Uint64)*, i8* } %"$$t1_0_247", 1
+  %"$uint64_two_250" = load %Uint64, %Uint64* %uint64_two
+  %"$$t1_0_call_251" = call %TName_Pair_Uint32_Uint64* %"$$t1_0_fptr_248"(i8* %"$$t1_0_envptr_249", %Uint64 %"$uint64_two_250")
+  store %TName_Pair_Uint32_Uint64* %"$$t1_0_call_251", %TName_Pair_Uint32_Uint64** %"$t1_1"
+  %"$$t1_1_252" = load %TName_Pair_Uint32_Uint64*, %TName_Pair_Uint32_Uint64** %"$t1_1"
+  store %TName_Pair_Uint32_Uint64* %"$$t1_1_252", %TName_Pair_Uint32_Uint64** %p1
+  %p2 = alloca %TName_Pair_ByStr1_ByStr2*
+  %"$t4_2" = alloca { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* }
+  %"$t4_253" = load { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* }, { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* }* %t4
+  %"$t4_fptr_254" = extractvalue { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } %"$t4_253", 0
+  %"$t4_envptr_255" = extractvalue { { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } (i8*, [1 x i8])*, i8* } %"$t4_253", 1
+  %"$addr_bystr1_256" = load [1 x i8], [1 x i8]* %addr_bystr1
+  %"$t4_call_257" = call { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } %"$t4_fptr_254"(i8* %"$t4_envptr_255", [1 x i8] %"$addr_bystr1_256")
+  store { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } %"$t4_call_257", { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* }* %"$t4_2"
+  %"$t4_3" = alloca %TName_Pair_ByStr1_ByStr2*
+  %"$$t4_2_258" = load { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* }, { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* }* %"$t4_2"
+  %"$$t4_2_fptr_259" = extractvalue { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } %"$$t4_2_258", 0
+  %"$$t4_2_envptr_260" = extractvalue { %TName_Pair_ByStr1_ByStr2* (i8*, [2 x i8])*, i8* } %"$$t4_2_258", 1
+  %"$addr_bystr2_261" = load [2 x i8], [2 x i8]* %addr_bystr2
+  %"$$t4_2_call_262" = call %TName_Pair_ByStr1_ByStr2* %"$$t4_2_fptr_259"(i8* %"$$t4_2_envptr_260", [2 x i8] %"$addr_bystr2_261")
+  store %TName_Pair_ByStr1_ByStr2* %"$$t4_2_call_262", %TName_Pair_ByStr1_ByStr2** %"$t4_3"
+  %"$$t4_3_263" = load %TName_Pair_ByStr1_ByStr2*, %TName_Pair_ByStr1_ByStr2** %"$t4_3"
+  store %TName_Pair_ByStr1_ByStr2* %"$$t4_3_263", %TName_Pair_ByStr1_ByStr2** %p2
+  %"$p1_264" = load %TName_Pair_Uint32_Uint64*, %TName_Pair_Uint32_Uint64** %p1
+  %"$p2_265" = load %TName_Pair_ByStr1_ByStr2*, %TName_Pair_ByStr1_ByStr2** %p2
+  %"$adtval_266_load" = load i8*, i8** @_execptr
+  %"$adtval_266_salloc" = call i8* @_salloc(i8* %"$adtval_266_load", i64 17)
+  %"$adtval_266" = bitcast i8* %"$adtval_266_salloc" to %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"*
+  %"$adtgep_267" = getelementptr inbounds %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)", %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* %"$adtval_266", i32 0, i32 0
+  store i8 0, i8* %"$adtgep_267"
+  %"$adtgep_268" = getelementptr inbounds %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)", %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* %"$adtval_266", i32 0, i32 1
+  store %TName_Pair_Uint32_Uint64* %"$p1_264", %TName_Pair_Uint32_Uint64** %"$adtgep_268"
+  %"$adtgep_269" = getelementptr inbounds %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)", %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* %"$adtval_266", i32 0, i32 2
+  store %TName_Pair_ByStr1_ByStr2* %"$p2_265", %TName_Pair_ByStr1_ByStr2** %"$adtgep_269"
+  %"$adtptr_270" = bitcast %"CName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* %"$adtval_266" to %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"*
+  store %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* %"$adtptr_270", %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"** %"$expr_4"
+  %"$$expr_4_271" = load %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"*, %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"** %"$expr_4"
+  ret %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* %"$$expr_4_271"
+}
+
+declare void @_print_scilla_val(%_TyDescrTy_Typ*, i8*)
+
+define void @scilla_main() {
+entry:
+  %"$exprval_272" = call %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* @"$scilla_expr_200"(i8* null)
+  %"$memvoidcast_273" = bitcast %"TName_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)"* %"$exprval_272" to i8*
+  call void @_print_scilla_val(%_TyDescrTy_Typ* @"$TyDescr_ADT_Pair_Pair_(Uint32)_(Uint64)_Pair_(ByStr1)_(ByStr2)_59", i8* %"$memvoidcast_273")
+  ret void
+}

--- a/tests/codegen/expr/tname_clash.scilexp
+++ b/tests/codegen/expr/tname_clash.scilexp
@@ -10,5 +10,7 @@ let tf2 =
   tfun 'B =>
     @tf 'B
 in
-@tf2 Int32 Int64
-
+let f = @tf2 Int32 Int64 in
+let one = Int32 1 in
+let two = Int64 2 in
+f one two

--- a/tests/codegen/expr/typ-inst.scilexp
+++ b/tests/codegen/expr/typ-inst.scilexp
@@ -5,4 +5,5 @@ let tf =
 in
 
 let t = @tf Uint32 in
-t
+let one = Uint32 1 in
+t one

--- a/tests/codegen/expr/typ1-inst.scilexp
+++ b/tests/codegen/expr/typ1-inst.scilexp
@@ -1,0 +1,12 @@
+let tf =
+  tfun 'A =>
+  tfun 'B =>
+  fun (a : 'A) =>
+  fun (b : 'B) =>
+    b
+in
+
+let t = @tf Uint32 Int32 in
+let one = Uint32 1 in
+let two = Int32 2 in
+t one two

--- a/tests/codegen/expr/typ2-inst.scilexp
+++ b/tests/codegen/expr/typ2-inst.scilexp
@@ -15,4 +15,11 @@ in
 
 let t1 = @tf1 Uint32 Uint64 in
 let t2 = @tf1 String ByStr20 in
-Pair {(Uint32 -> Uint64 -> Pair (Uint32) (Uint64)) (String -> ByStr20 -> (Pair String ByStr20))} t1 t2
+let uint32_one = Uint32 1 in
+let uint64_two = Uint64 2 in
+let hello_string = "hello" in
+let addr_bystr20 = 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa in
+
+let p1 = t1 uint32_one uint64_two in
+let p2 = t2 hello_string addr_bystr20 in
+Pair {(Pair (Uint32) (Uint64)) ((Pair String ByStr20))} p1 p2

--- a/tests/codegen/expr/typ3-inst.scilexp
+++ b/tests/codegen/expr/typ3-inst.scilexp
@@ -16,4 +16,11 @@ in
 let t1 = @tf1 Uint32 Uint64 in
 let t3 = @tf ByStr1 in
 let t4 = @t3 ByStr2 in
-Pair {(Uint32 -> Uint64 -> Pair (Uint32) (Uint64)) (ByStr1 -> ByStr2 -> (Pair ByStr1 ByStr2))} t1 t4
+let uint32_one = Uint32 1 in
+let uint64_two = Uint64 2 in
+let addr_bystr1 = 0xaa in
+let addr_bystr2 = 0xaabb in
+
+let p1 = t1 uint32_one uint64_two in
+let p2 = t4 addr_bystr1 addr_bystr2 in
+Pair {(Pair (Uint32) (Uint64)) ((Pair ByStr1 ByStr2))} p1 p2


### PR DESCRIPTION
TFunMap expressions translate to creation of dynamic dispatch tables, indexed by types and TFunSel expressions translate to indexing into the dynamic dispatch tables, and getting the monomorphized expressions out.