### PR TITLE
feat(deps): Support LLVM 14.0.6

### DIFF
--- a/scilla-compiler.opam
+++ b/scilla-compiler.opam
@@ -8,10 +8,11 @@ license: "GPL-3.0"
 depends: [
   "ocamlfind"
   "batteries"
+  "dune-build-info"
   "core" {>= "v0.15.0" & < "v0.16.0~"}
   "core_unix" {>= "v0.15.0" & < "v0.16.0~"}
   "scilla"
-  "llvm" {>= "13.0.0" & < "13.1~"}
+  "llvm" {>= "13.0.0" & <= "14.0.6"}
 ]
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]

--- a/tests/Testsuite.ml
+++ b/tests/Testsuite.ml
@@ -17,5 +17,32 @@
 *)
 
 open Scilla_test.Util
+open Core
 
-let () = run_tests [ TestCodegenExpr.All.tests; TestCodegenContr.All.tests ]
+let llvm_version () =
+  let open Build_info.V1 in
+  let rec find_llvm = function
+    | l :: lr ->
+        if String.equal "llvm" @@ Statically_linked_library.name l then
+          match Statically_linked_library.version l with
+          | None -> None
+          | Some v -> Version.to_string v |> Option.some
+        else find_llvm lr
+    | [] -> None
+  in
+  Statically_linked_libraries.to_list ()
+  |> find_llvm
+  |> Option.value ~default:"n/a"
+
+let () =
+  let tests = [ TestCodegenExpr.Common.tests; TestCodegenContr.Common.tests ] in
+  (* Tests for DebugInfo should be used with LLVM 13.0.0.
+     Newer versions of LLVM generate the different debug metadata because of
+     the changes introduced in:
+     https://reviews.llvm.org/rG47b239eb5a17065d13c317600c46e56ffe2d6c75*)
+  let tests =
+    if String.equal "13.0.0" @@ llvm_version () then
+      tests @ [ TestCodegenExpr.DI.tests; TestCodegenContr.DI.tests ]
+    else tests
+  in
+  run_tests tests

--- a/tests/codegen/contr/TestCodegenContr.ml
+++ b/tests/codegen/contr/TestCodegenContr.ml
@@ -105,13 +105,12 @@ end
 
 module Tests_With_Init_DI = Scilla_test.Util.DiffBasedTests (TestM_With_Init_DI)
 
-module All = struct
+module Common = struct
   let tests env =
-    "codegen_contr"
-    >::: [
-           Tests.tests env;
-           Tests_DI.tests env;
-           Tests_With_Init.tests env;
-           Tests_With_Init_DI.tests env;
-         ]
+    "codegen_contr_common" >::: [ Tests.tests env; Tests_With_Init.tests env ]
+end
+
+module DI = struct
+  let tests env =
+    "codegen_contr_di" >::: [ Tests_DI.tests env; Tests_With_Init_DI.tests env ]
 end

--- a/tests/codegen/expr/TestCodegenExpr.ml
+++ b/tests/codegen/expr/TestCodegenExpr.ml
@@ -175,8 +175,11 @@ module Tests_DI = Scilla_test.Util.DiffBasedTests (struct
   let diff_filter = diff_filter
 end)
 
-module All = struct
+module Common = struct
   let tests env =
-    "codegen_expr"
-    >::: [ Tests.tests env; TestsFail.tests env; Tests_DI.tests env ]
+    "codegen_expr_common" >::: [ Tests.tests env; TestsFail.tests env ]
+end
+
+module DI = struct
+  let tests env = "codegen_expr_di" >::: [ Tests_DI.tests env ]
 end

--- a/tests/dune
+++ b/tests/dune
@@ -3,4 +3,4 @@
  (names testsuite)
  (preprocess
   (pps ppx_sexp_conv ppx_let ppx_deriving.show))
- (libraries core oUnit testcodegenexpr testcodegencontr))
+ (libraries core oUnit dune-build-info llvm testcodegenexpr testcodegencontr))


### PR DESCRIPTION
Add support for the latest stable LLVM 14.0.6.

Some tests were separated. They require LLVM 13, because the recent versions of LLVM contain incompatible changes introduced here: https://reviews.llvm.org/D107024.

Closes #97